### PR TITLE
feat: add network, volume, system, auth commands and CI workflows

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,28 @@
+version: 2
+updates:
+  - package-ecosystem: gradle
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    labels:
+      - dependencies
+      - gradle
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    labels:
+      - dependencies
+      - github-actions
+
+  - package-ecosystem: pip
+    directory: /
+    schedule:
+      interval: monthly
+    open-pull-requests-limit: 3
+    labels:
+      - dependencies
+      - documentation

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,72 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        java: [17, 21]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up JDK ${{ matrix.java }}
+        uses: actions/setup-java@v4
+        with:
+          java-version: ${{ matrix.java }}
+          distribution: temurin
+          cache: gradle
+
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
+
+      - name: Build
+        run: ./gradlew build
+
+      - name: Run tests
+        run: ./gradlew test
+
+      - name: Upload test results
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: test-results-java-${{ matrix.java }}
+          path: '**/build/reports/tests/'
+          retention-days: 7
+
+  integration-tests:
+    runs-on: ubuntu-latest
+    needs: build
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          java-version: 17
+          distribution: temurin
+          cache: gradle
+
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
+
+      - name: Run integration tests
+        run: ./gradlew test
+        env:
+          DOCKER_TESTS_ENABLED: true
+
+      - name: Upload integration test results
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: integration-test-results
+          path: '**/build/reports/tests/'
+          retention-days: 7

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,55 @@
+name: Documentation
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'docs/**'
+      - 'mkdocs.yml'
+      - '.github/workflows/docs.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install dependencies
+        run: |
+          pip install mkdocs-material mkdocs-minify-plugin
+
+      - name: Build documentation
+        run: mkdocs build --strict
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: site
+
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,39 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          java-version: 17
+          distribution: temurin
+          cache: gradle
+
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
+
+      - name: Build
+        run: ./gradlew build
+
+      - name: Run tests
+        run: ./gradlew test
+
+      - name: Create Release
+        uses: softprops/action-gh-release@v2
+        with:
+          generate_release_notes: true
+          files: |
+            **/build/libs/*.jar

--- a/docker-kotlin-core/src/main/kotlin/io/github/joshrotenberg/dockerkotlin/core/command/ImagePruneCommand.kt
+++ b/docker-kotlin-core/src/main/kotlin/io/github/joshrotenberg/dockerkotlin/core/command/ImagePruneCommand.kt
@@ -1,0 +1,68 @@
+package io.github.joshrotenberg.dockerkotlin.core.command
+
+import io.github.joshrotenberg.dockerkotlin.core.CommandExecutor
+
+/**
+ * Command to remove unused images.
+ *
+ * Equivalent to `docker image prune`.
+ *
+ * Example usage:
+ * ```kotlin
+ * ImagePruneCommand().force().executeBlocking()
+ * ImagePruneCommand().all().force().executeBlocking()
+ * ImagePruneCommand().until("24h").force().executeBlocking()
+ * ```
+ */
+class ImagePruneCommand(
+    executor: CommandExecutor = CommandExecutor()
+) : AbstractDockerCommand<String>(executor) {
+
+    private var all = false
+    private var force = false
+    private val filters = mutableMapOf<String, String>()
+
+    /** Remove all unused images, not just dangling ones. */
+    fun all() = apply { all = true }
+
+    /** Do not prompt for confirmation. */
+    fun force() = apply { force = true }
+
+    /** Add a filter (e.g., "until=24h", "label=foo=bar"). */
+    fun filter(key: String, value: String) = apply { filters[key] = value }
+
+    /** Filter by label. */
+    fun labelFilter(label: String) = apply { filter("label", label) }
+
+    /** Prune images older than the specified duration. */
+    fun until(duration: String) = apply { filter("until", duration) }
+
+    /** Only remove dangling images (default behavior). */
+    fun danglingOnly() = apply { filter("dangling", "true") }
+
+    override fun buildArgs(): List<String> = buildList {
+        add("image")
+        add("prune")
+
+        if (all) add("--all")
+        if (force) add("--force")
+
+        filters.forEach { (key, value) ->
+            add("--filter")
+            add("$key=$value")
+        }
+    }
+
+    override suspend fun execute(): String {
+        return executeRaw().stdout
+    }
+
+    override fun executeBlocking(): String {
+        return executeRawBlocking().stdout
+    }
+
+    companion object {
+        @JvmStatic
+        fun builder(): ImagePruneCommand = ImagePruneCommand()
+    }
+}

--- a/docker-kotlin-core/src/main/kotlin/io/github/joshrotenberg/dockerkotlin/core/command/LoginCommand.kt
+++ b/docker-kotlin-core/src/main/kotlin/io/github/joshrotenberg/dockerkotlin/core/command/LoginCommand.kt
@@ -1,0 +1,61 @@
+package io.github.joshrotenberg.dockerkotlin.core.command
+
+import io.github.joshrotenberg.dockerkotlin.core.CommandExecutor
+
+/**
+ * Command to log in to a Docker registry.
+ *
+ * Equivalent to `docker login`.
+ *
+ * Example usage:
+ * ```kotlin
+ * LoginCommand("myuser", "mypassword").executeBlocking()
+ * LoginCommand("myuser", "mypassword").registry("gcr.io").executeBlocking()
+ * ```
+ *
+ * Note: For security, prefer using `passwordStdin()` in production environments.
+ */
+class LoginCommand(
+    private val username: String,
+    private val password: String,
+    executor: CommandExecutor = CommandExecutor()
+) : AbstractDockerCommand<String>(executor) {
+
+    private var registry: String? = null
+    private var passwordStdin = false
+
+    /** Set the registry server URL (defaults to Docker Hub). */
+    fun registry(registry: String) = apply { this.registry = registry }
+
+    /** Read password from stdin for security. */
+    fun passwordStdin() = apply { passwordStdin = true }
+
+    override fun buildArgs(): List<String> = buildList {
+        add("login")
+        add("--username")
+        add(username)
+
+        if (passwordStdin) {
+            add("--password-stdin")
+        } else {
+            add("--password")
+            add(password)
+        }
+
+        registry?.let { add(it) }
+    }
+
+    override suspend fun execute(): String {
+        return executeRaw().stdout
+    }
+
+    override fun executeBlocking(): String {
+        return executeRawBlocking().stdout
+    }
+
+    companion object {
+        @JvmStatic
+        fun builder(username: String, password: String): LoginCommand =
+            LoginCommand(username, password)
+    }
+}

--- a/docker-kotlin-core/src/main/kotlin/io/github/joshrotenberg/dockerkotlin/core/command/LogoutCommand.kt
+++ b/docker-kotlin-core/src/main/kotlin/io/github/joshrotenberg/dockerkotlin/core/command/LogoutCommand.kt
@@ -1,0 +1,42 @@
+package io.github.joshrotenberg.dockerkotlin.core.command
+
+import io.github.joshrotenberg.dockerkotlin.core.CommandExecutor
+
+/**
+ * Command to log out from a Docker registry.
+ *
+ * Equivalent to `docker logout`.
+ *
+ * Example usage:
+ * ```kotlin
+ * LogoutCommand().executeBlocking()
+ * LogoutCommand().server("gcr.io").executeBlocking()
+ * ```
+ */
+class LogoutCommand(
+    executor: CommandExecutor = CommandExecutor()
+) : AbstractDockerCommand<String>(executor) {
+
+    private var server: String? = null
+
+    /** Set the registry server to log out from (defaults to Docker Hub). */
+    fun server(server: String) = apply { this.server = server }
+
+    override fun buildArgs(): List<String> = buildList {
+        add("logout")
+        server?.let { add(it) }
+    }
+
+    override suspend fun execute(): String {
+        return executeRaw().stdout
+    }
+
+    override fun executeBlocking(): String {
+        return executeRawBlocking().stdout
+    }
+
+    companion object {
+        @JvmStatic
+        fun builder(): LogoutCommand = LogoutCommand()
+    }
+}

--- a/docker-kotlin-core/src/main/kotlin/io/github/joshrotenberg/dockerkotlin/core/command/network/NetworkConnectCommand.kt
+++ b/docker-kotlin-core/src/main/kotlin/io/github/joshrotenberg/dockerkotlin/core/command/network/NetworkConnectCommand.kt
@@ -1,0 +1,79 @@
+package io.github.joshrotenberg.dockerkotlin.core.command.network
+
+import io.github.joshrotenberg.dockerkotlin.core.CommandExecutor
+import io.github.joshrotenberg.dockerkotlin.core.command.AbstractDockerCommand
+
+/**
+ * Command to connect a container to a network.
+ *
+ * Equivalent to `docker network connect`.
+ *
+ * Example usage:
+ * ```kotlin
+ * NetworkConnectCommand("my-network", "my-container")
+ *     .ipv4("172.20.0.10")
+ *     .alias("db")
+ *     .executeBlocking()
+ * ```
+ */
+class NetworkConnectCommand(
+    private val network: String,
+    private val container: String,
+    executor: CommandExecutor = CommandExecutor()
+) : AbstractDockerCommand<Unit>(executor) {
+
+    private var ipv4: String? = null
+    private var ipv6: String? = null
+    private val aliases = mutableListOf<String>()
+    private val links = mutableListOf<String>()
+    private val linkLocalIps = mutableListOf<String>()
+    private val driverOpts = mutableListOf<Pair<String, String>>()
+
+    /** Set IPv4 address. */
+    fun ipv4(ip: String) = apply { this.ipv4 = ip }
+
+    /** Set IPv6 address. */
+    fun ipv6(ip: String) = apply { this.ipv6 = ip }
+
+    /** Add a network-scoped alias. */
+    fun alias(alias: String) = apply { aliases.add(alias) }
+
+    /** Add a link to another container. */
+    fun link(container: String) = apply { links.add(container) }
+
+    /** Add a link-local IP address. */
+    fun linkLocalIp(ip: String) = apply { linkLocalIps.add(ip) }
+
+    /** Add a driver option. */
+    fun driverOpt(key: String, value: String) = apply { driverOpts.add(key to value) }
+
+    override fun buildArgs(): List<String> = buildList {
+        add("network")
+        add("connect")
+
+        ipv4?.let { add("--ip"); add(it) }
+        ipv6?.let { add("--ip6"); add(it) }
+
+        aliases.forEach { add("--alias"); add(it) }
+        links.forEach { add("--link"); add(it) }
+        linkLocalIps.forEach { add("--link-local-ip"); add(it) }
+        driverOpts.forEach { (key, value) -> add("--driver-opt"); add("$key=$value") }
+
+        add(network)
+        add(container)
+    }
+
+    override suspend fun execute() {
+        executeRaw()
+    }
+
+    override fun executeBlocking() {
+        executeRawBlocking()
+    }
+
+    companion object {
+        @JvmStatic
+        fun builder(network: String, container: String): NetworkConnectCommand =
+            NetworkConnectCommand(network, container)
+    }
+}

--- a/docker-kotlin-core/src/main/kotlin/io/github/joshrotenberg/dockerkotlin/core/command/network/NetworkCreateCommand.kt
+++ b/docker-kotlin-core/src/main/kotlin/io/github/joshrotenberg/dockerkotlin/core/command/network/NetworkCreateCommand.kt
@@ -1,0 +1,130 @@
+package io.github.joshrotenberg.dockerkotlin.core.command.network
+
+import io.github.joshrotenberg.dockerkotlin.core.CommandExecutor
+import io.github.joshrotenberg.dockerkotlin.core.command.AbstractDockerCommand
+
+/**
+ * Command to create a Docker network.
+ *
+ * Equivalent to `docker network create`.
+ *
+ * Example usage:
+ * ```kotlin
+ * NetworkCreateCommand("my-network")
+ *     .driver("bridge")
+ *     .subnet("172.20.0.0/16")
+ *     .executeBlocking()
+ * ```
+ */
+class NetworkCreateCommand(
+    private val name: String,
+    executor: CommandExecutor = CommandExecutor()
+) : AbstractDockerCommand<String>(executor) {
+
+    private var driver: String? = null
+    private val driverOpts = mutableMapOf<String, String>()
+    private var subnet: String? = null
+    private var ipRange: String? = null
+    private var gateway: String? = null
+    private var ipv6 = false
+    private var attachable = false
+    private var internal = false
+    private val labels = mutableMapOf<String, String>()
+    private var scope: String? = null
+    private var configFrom: String? = null
+    private var configOnly = false
+    private var ingress = false
+    private val auxAddresses = mutableMapOf<String, String>()
+
+    /** Set the network driver (bridge, overlay, macvlan, none, etc.). */
+    fun driver(driver: String) = apply { this.driver = driver }
+
+    /** Add a driver-specific option. */
+    fun driverOpt(key: String, value: String) = apply { driverOpts[key] = value }
+
+    /** Set the subnet in CIDR format (e.g., "172.20.0.0/16"). */
+    fun subnet(subnet: String) = apply { this.subnet = subnet }
+
+    /** Set the IP range in CIDR format. */
+    fun ipRange(range: String) = apply { this.ipRange = range }
+
+    /** Set the gateway IP address. */
+    fun gateway(gateway: String) = apply { this.gateway = gateway }
+
+    /** Enable IPv6 networking. */
+    fun ipv6() = apply { ipv6 = true }
+
+    /** Enable manual container attachment. */
+    fun attachable() = apply { attachable = true }
+
+    /** Restrict external access to the network. */
+    fun internal() = apply { internal = true }
+
+    /** Add a network label. */
+    fun label(key: String, value: String) = apply { labels[key] = value }
+
+    /** Set network scope (local, swarm, global). */
+    fun scope(scope: String) = apply { this.scope = scope }
+
+    /** Create network from existing config. */
+    fun configFrom(network: String) = apply { this.configFrom = network }
+
+    /** Config only (don't create network). */
+    fun configOnly() = apply { configOnly = true }
+
+    /** Create an ingress network. */
+    fun ingress() = apply { ingress = true }
+
+    /** Add auxiliary address. */
+    fun auxAddress(name: String, ip: String) = apply { auxAddresses[name] = ip }
+
+    override fun buildArgs(): List<String> = buildList {
+        add("network")
+        add("create")
+
+        driver?.let { add("--driver"); add(it) }
+
+        driverOpts.forEach { (key, value) ->
+            add("--opt")
+            add("$key=$value")
+        }
+
+        subnet?.let { add("--subnet"); add(it) }
+        ipRange?.let { add("--ip-range"); add(it) }
+        gateway?.let { add("--gateway"); add(it) }
+
+        if (ipv6) add("--ipv6")
+        if (attachable) add("--attachable")
+        if (internal) add("--internal")
+
+        labels.forEach { (key, value) ->
+            add("--label")
+            add("$key=$value")
+        }
+
+        scope?.let { add("--scope"); add(it) }
+        configFrom?.let { add("--config-from"); add(it) }
+        if (configOnly) add("--config-only")
+        if (ingress) add("--ingress")
+
+        auxAddresses.forEach { (name, ip) ->
+            add("--aux-address")
+            add("$name=$ip")
+        }
+
+        add(name)
+    }
+
+    override suspend fun execute(): String {
+        return executeRaw().stdout.trim()
+    }
+
+    override fun executeBlocking(): String {
+        return executeRawBlocking().stdout.trim()
+    }
+
+    companion object {
+        @JvmStatic
+        fun builder(name: String): NetworkCreateCommand = NetworkCreateCommand(name)
+    }
+}

--- a/docker-kotlin-core/src/main/kotlin/io/github/joshrotenberg/dockerkotlin/core/command/network/NetworkDisconnectCommand.kt
+++ b/docker-kotlin-core/src/main/kotlin/io/github/joshrotenberg/dockerkotlin/core/command/network/NetworkDisconnectCommand.kt
@@ -1,0 +1,49 @@
+package io.github.joshrotenberg.dockerkotlin.core.command.network
+
+import io.github.joshrotenberg.dockerkotlin.core.CommandExecutor
+import io.github.joshrotenberg.dockerkotlin.core.command.AbstractDockerCommand
+
+/**
+ * Command to disconnect a container from a network.
+ *
+ * Equivalent to `docker network disconnect`.
+ *
+ * Example usage:
+ * ```kotlin
+ * NetworkDisconnectCommand("my-network", "my-container").executeBlocking()
+ * NetworkDisconnectCommand("my-network", "my-container").force().executeBlocking()
+ * ```
+ */
+class NetworkDisconnectCommand(
+    private val network: String,
+    private val container: String,
+    executor: CommandExecutor = CommandExecutor()
+) : AbstractDockerCommand<Unit>(executor) {
+
+    private var force = false
+
+    /** Force disconnection. */
+    fun force() = apply { force = true }
+
+    override fun buildArgs(): List<String> = buildList {
+        add("network")
+        add("disconnect")
+        if (force) add("--force")
+        add(network)
+        add(container)
+    }
+
+    override suspend fun execute() {
+        executeRaw()
+    }
+
+    override fun executeBlocking() {
+        executeRawBlocking()
+    }
+
+    companion object {
+        @JvmStatic
+        fun builder(network: String, container: String): NetworkDisconnectCommand =
+            NetworkDisconnectCommand(network, container)
+    }
+}

--- a/docker-kotlin-core/src/main/kotlin/io/github/joshrotenberg/dockerkotlin/core/command/network/NetworkInspectCommand.kt
+++ b/docker-kotlin-core/src/main/kotlin/io/github/joshrotenberg/dockerkotlin/core/command/network/NetworkInspectCommand.kt
@@ -1,0 +1,60 @@
+package io.github.joshrotenberg.dockerkotlin.core.command.network
+
+import io.github.joshrotenberg.dockerkotlin.core.CommandExecutor
+import io.github.joshrotenberg.dockerkotlin.core.command.AbstractDockerCommand
+
+/**
+ * Command to display detailed information on one or more networks.
+ *
+ * Equivalent to `docker network inspect`.
+ *
+ * Example usage:
+ * ```kotlin
+ * NetworkInspectCommand("my-network").executeBlocking()
+ * NetworkInspectCommand("my-network").format("{{.Driver}}").executeBlocking()
+ * ```
+ */
+class NetworkInspectCommand : AbstractDockerCommand<String> {
+
+    private val networks: List<String>
+    private var format: String? = null
+    private var verbose = false
+
+    constructor(network: String, executor: CommandExecutor = CommandExecutor()) : super(executor) {
+        this.networks = listOf(network)
+    }
+
+    constructor(networks: List<String>, executor: CommandExecutor = CommandExecutor()) : super(executor) {
+        this.networks = networks
+    }
+
+    /** Set output format using Go template. */
+    fun format(format: String) = apply { this.format = format }
+
+    /** Include verbose information. */
+    fun verbose() = apply { verbose = true }
+
+    override fun buildArgs(): List<String> = buildList {
+        add("network")
+        add("inspect")
+        format?.let { add("--format"); add(it) }
+        if (verbose) add("--verbose")
+        addAll(networks)
+    }
+
+    override suspend fun execute(): String {
+        return executeRaw().stdout
+    }
+
+    override fun executeBlocking(): String {
+        return executeRawBlocking().stdout
+    }
+
+    companion object {
+        @JvmStatic
+        fun builder(network: String): NetworkInspectCommand = NetworkInspectCommand(network)
+
+        @JvmStatic
+        fun builder(networks: List<String>): NetworkInspectCommand = NetworkInspectCommand(networks)
+    }
+}

--- a/docker-kotlin-core/src/main/kotlin/io/github/joshrotenberg/dockerkotlin/core/command/network/NetworkLsCommand.kt
+++ b/docker-kotlin-core/src/main/kotlin/io/github/joshrotenberg/dockerkotlin/core/command/network/NetworkLsCommand.kt
@@ -1,0 +1,86 @@
+package io.github.joshrotenberg.dockerkotlin.core.command.network
+
+import io.github.joshrotenberg.dockerkotlin.core.CommandExecutor
+import io.github.joshrotenberg.dockerkotlin.core.command.AbstractDockerCommand
+
+/**
+ * Command to list Docker networks.
+ *
+ * Equivalent to `docker network ls`.
+ *
+ * Example usage:
+ * ```kotlin
+ * NetworkLsCommand()
+ *     .driverFilter("bridge")
+ *     .executeBlocking()
+ * ```
+ */
+class NetworkLsCommand(
+    executor: CommandExecutor = CommandExecutor()
+) : AbstractDockerCommand<String>(executor) {
+
+    private val filters = mutableMapOf<String, String>()
+    private var format: String? = null
+    private var noTrunc = false
+    private var quiet = false
+
+    /** Add a filter. */
+    fun filter(key: String, value: String) = apply { filters[key] = value }
+
+    /** Filter by driver. */
+    fun driverFilter(driver: String) = apply { filter("driver", driver) }
+
+    /** Filter by ID. */
+    fun idFilter(id: String) = apply { filter("id", id) }
+
+    /** Filter by label. */
+    fun labelFilter(label: String) = apply { filter("label", label) }
+
+    /** Filter by name. */
+    fun nameFilter(name: String) = apply { filter("name", name) }
+
+    /** Filter by scope. */
+    fun scopeFilter(scope: String) = apply { filter("scope", scope) }
+
+    /** Filter by type (custom or builtin). */
+    fun typeFilter(type: String) = apply { filter("type", type) }
+
+    /** Set output format. */
+    fun format(format: String) = apply { this.format = format }
+
+    /** Format output as JSON. */
+    fun formatJson() = apply { format = "json" }
+
+    /** Don't truncate output. */
+    fun noTrunc() = apply { noTrunc = true }
+
+    /** Only display network IDs. */
+    fun quiet() = apply { quiet = true }
+
+    override fun buildArgs(): List<String> = buildList {
+        add("network")
+        add("ls")
+
+        filters.forEach { (key, value) ->
+            add("--filter")
+            add("$key=$value")
+        }
+
+        format?.let { add("--format"); add(it) }
+        if (noTrunc) add("--no-trunc")
+        if (quiet) add("--quiet")
+    }
+
+    override suspend fun execute(): String {
+        return executeRaw().stdout
+    }
+
+    override fun executeBlocking(): String {
+        return executeRawBlocking().stdout
+    }
+
+    companion object {
+        @JvmStatic
+        fun builder(): NetworkLsCommand = NetworkLsCommand()
+    }
+}

--- a/docker-kotlin-core/src/main/kotlin/io/github/joshrotenberg/dockerkotlin/core/command/network/NetworkPruneCommand.kt
+++ b/docker-kotlin-core/src/main/kotlin/io/github/joshrotenberg/dockerkotlin/core/command/network/NetworkPruneCommand.kt
@@ -1,0 +1,66 @@
+package io.github.joshrotenberg.dockerkotlin.core.command.network
+
+import io.github.joshrotenberg.dockerkotlin.core.CommandExecutor
+import io.github.joshrotenberg.dockerkotlin.core.command.AbstractDockerCommand
+
+/**
+ * Command to remove all unused networks.
+ *
+ * Equivalent to `docker network prune`.
+ *
+ * Example usage:
+ * ```kotlin
+ * NetworkPruneCommand().force().executeBlocking()
+ * NetworkPruneCommand().until("24h").force().executeBlocking()
+ * ```
+ */
+class NetworkPruneCommand(
+    executor: CommandExecutor = CommandExecutor()
+) : AbstractDockerCommand<String>(executor) {
+
+    private var until: String? = null
+    private val filters = mutableMapOf<String, String>()
+    private var force = false
+
+    /** Remove networks created before given timestamp. */
+    fun until(timestamp: String) = apply { this.until = timestamp }
+
+    /** Add a filter. */
+    fun filter(key: String, value: String) = apply { filters[key] = value }
+
+    /** Filter by label. */
+    fun labelFilter(label: String) = apply { filter("label", label) }
+
+    /** Do not prompt for confirmation. */
+    fun force() = apply { force = true }
+
+    override fun buildArgs(): List<String> = buildList {
+        add("network")
+        add("prune")
+
+        until?.let {
+            add("--filter")
+            add("until=$it")
+        }
+
+        filters.forEach { (key, value) ->
+            add("--filter")
+            add("$key=$value")
+        }
+
+        if (force) add("--force")
+    }
+
+    override suspend fun execute(): String {
+        return executeRaw().stdout
+    }
+
+    override fun executeBlocking(): String {
+        return executeRawBlocking().stdout
+    }
+
+    companion object {
+        @JvmStatic
+        fun builder(): NetworkPruneCommand = NetworkPruneCommand()
+    }
+}

--- a/docker-kotlin-core/src/main/kotlin/io/github/joshrotenberg/dockerkotlin/core/command/network/NetworkRmCommand.kt
+++ b/docker-kotlin-core/src/main/kotlin/io/github/joshrotenberg/dockerkotlin/core/command/network/NetworkRmCommand.kt
@@ -1,0 +1,55 @@
+package io.github.joshrotenberg.dockerkotlin.core.command.network
+
+import io.github.joshrotenberg.dockerkotlin.core.CommandExecutor
+import io.github.joshrotenberg.dockerkotlin.core.command.AbstractDockerCommand
+
+/**
+ * Command to remove one or more Docker networks.
+ *
+ * Equivalent to `docker network rm`.
+ *
+ * Example usage:
+ * ```kotlin
+ * NetworkRmCommand("my-network").executeBlocking()
+ * NetworkRmCommand(listOf("net1", "net2")).force().executeBlocking()
+ * ```
+ */
+class NetworkRmCommand : AbstractDockerCommand<String> {
+
+    private val networks: List<String>
+    private var force = false
+
+    constructor(network: String, executor: CommandExecutor = CommandExecutor()) : super(executor) {
+        this.networks = listOf(network)
+    }
+
+    constructor(networks: List<String>, executor: CommandExecutor = CommandExecutor()) : super(executor) {
+        this.networks = networks
+    }
+
+    /** Force removal. */
+    fun force() = apply { force = true }
+
+    override fun buildArgs(): List<String> = buildList {
+        add("network")
+        add("rm")
+        if (force) add("--force")
+        addAll(networks)
+    }
+
+    override suspend fun execute(): String {
+        return executeRaw().stdout
+    }
+
+    override fun executeBlocking(): String {
+        return executeRawBlocking().stdout
+    }
+
+    companion object {
+        @JvmStatic
+        fun builder(network: String): NetworkRmCommand = NetworkRmCommand(network)
+
+        @JvmStatic
+        fun builder(networks: List<String>): NetworkRmCommand = NetworkRmCommand(networks)
+    }
+}

--- a/docker-kotlin-core/src/main/kotlin/io/github/joshrotenberg/dockerkotlin/core/command/system/SystemDfCommand.kt
+++ b/docker-kotlin-core/src/main/kotlin/io/github/joshrotenberg/dockerkotlin/core/command/system/SystemDfCommand.kt
@@ -1,0 +1,52 @@
+package io.github.joshrotenberg.dockerkotlin.core.command.system
+
+import io.github.joshrotenberg.dockerkotlin.core.CommandExecutor
+import io.github.joshrotenberg.dockerkotlin.core.command.AbstractDockerCommand
+
+/**
+ * Command to show Docker disk usage.
+ *
+ * Equivalent to `docker system df`.
+ *
+ * Example usage:
+ * ```kotlin
+ * SystemDfCommand().executeBlocking()
+ * SystemDfCommand().verbose().executeBlocking()
+ * ```
+ */
+class SystemDfCommand(
+    executor: CommandExecutor = CommandExecutor()
+) : AbstractDockerCommand<String>(executor) {
+
+    private var verbose = false
+    private var format: String? = null
+
+    /** Show detailed information on space usage. */
+    fun verbose() = apply { verbose = true }
+
+    /** Format output using a custom template. */
+    fun format(format: String) = apply { this.format = format }
+
+    /** Format output as JSON. */
+    fun formatJson() = apply { format = "json" }
+
+    override fun buildArgs(): List<String> = buildList {
+        add("system")
+        add("df")
+        if (verbose) add("--verbose")
+        format?.let { add("--format"); add(it) }
+    }
+
+    override suspend fun execute(): String {
+        return executeRaw().stdout
+    }
+
+    override fun executeBlocking(): String {
+        return executeRawBlocking().stdout
+    }
+
+    companion object {
+        @JvmStatic
+        fun builder(): SystemDfCommand = SystemDfCommand()
+    }
+}

--- a/docker-kotlin-core/src/main/kotlin/io/github/joshrotenberg/dockerkotlin/core/command/system/SystemPruneCommand.kt
+++ b/docker-kotlin-core/src/main/kotlin/io/github/joshrotenberg/dockerkotlin/core/command/system/SystemPruneCommand.kt
@@ -1,0 +1,77 @@
+package io.github.joshrotenberg.dockerkotlin.core.command.system
+
+import io.github.joshrotenberg.dockerkotlin.core.CommandExecutor
+import io.github.joshrotenberg.dockerkotlin.core.command.AbstractDockerCommand
+
+/**
+ * Command to remove unused Docker data.
+ *
+ * Removes:
+ * - All stopped containers
+ * - All networks not used by at least one container
+ * - All dangling images
+ * - All dangling build cache
+ * - Optionally all volumes not used by at least one container
+ *
+ * Equivalent to `docker system prune`.
+ *
+ * Example usage:
+ * ```kotlin
+ * SystemPruneCommand().force().executeBlocking()
+ * SystemPruneCommand().all().volumes().force().executeBlocking()
+ * ```
+ */
+class SystemPruneCommand(
+    executor: CommandExecutor = CommandExecutor()
+) : AbstractDockerCommand<String>(executor) {
+
+    private var all = false
+    private var volumes = false
+    private var force = false
+    private val filters = mutableMapOf<String, String>()
+
+    /** Remove all unused images, not just dangling ones. */
+    fun all() = apply { all = true }
+
+    /** Prune volumes as well. */
+    fun volumes() = apply { volumes = true }
+
+    /** Do not prompt for confirmation. */
+    fun force() = apply { force = true }
+
+    /** Add a filter (e.g., "until=24h", "label=foo=bar"). */
+    fun filter(key: String, value: String) = apply { filters[key] = value }
+
+    /** Filter by label. */
+    fun labelFilter(label: String) = apply { filter("label", label) }
+
+    /** Prune objects older than the specified duration. */
+    fun until(duration: String) = apply { filter("until", duration) }
+
+    override fun buildArgs(): List<String> = buildList {
+        add("system")
+        add("prune")
+
+        if (all) add("--all")
+        if (volumes) add("--volumes")
+        if (force) add("--force")
+
+        filters.forEach { (key, value) ->
+            add("--filter")
+            add("$key=$value")
+        }
+    }
+
+    override suspend fun execute(): String {
+        return executeRaw().stdout
+    }
+
+    override fun executeBlocking(): String {
+        return executeRawBlocking().stdout
+    }
+
+    companion object {
+        @JvmStatic
+        fun builder(): SystemPruneCommand = SystemPruneCommand()
+    }
+}

--- a/docker-kotlin-core/src/main/kotlin/io/github/joshrotenberg/dockerkotlin/core/command/volume/VolumeCreateCommand.kt
+++ b/docker-kotlin-core/src/main/kotlin/io/github/joshrotenberg/dockerkotlin/core/command/volume/VolumeCreateCommand.kt
@@ -1,0 +1,71 @@
+package io.github.joshrotenberg.dockerkotlin.core.command.volume
+
+import io.github.joshrotenberg.dockerkotlin.core.CommandExecutor
+import io.github.joshrotenberg.dockerkotlin.core.command.AbstractDockerCommand
+
+/**
+ * Command to create a Docker volume.
+ *
+ * Equivalent to `docker volume create`.
+ *
+ * Example usage:
+ * ```kotlin
+ * VolumeCreateCommand()
+ *     .name("my-volume")
+ *     .driver("local")
+ *     .executeBlocking()
+ * ```
+ */
+class VolumeCreateCommand(
+    executor: CommandExecutor = CommandExecutor()
+) : AbstractDockerCommand<String>(executor) {
+
+    private var name: String? = null
+    private var driver: String? = null
+    private val driverOpts = mutableMapOf<String, String>()
+    private val labels = mutableMapOf<String, String>()
+
+    /** Set volume name. */
+    fun name(name: String) = apply { this.name = name }
+
+    /** Set the volume driver. */
+    fun driver(driver: String) = apply { this.driver = driver }
+
+    /** Add a driver option. */
+    fun driverOpt(key: String, value: String) = apply { driverOpts[key] = value }
+
+    /** Add a label. */
+    fun label(key: String, value: String) = apply { labels[key] = value }
+
+    override fun buildArgs(): List<String> = buildList {
+        add("volume")
+        add("create")
+
+        driver?.let { add("--driver"); add(it) }
+
+        driverOpts.forEach { (key, value) ->
+            add("--opt")
+            add("$key=$value")
+        }
+
+        labels.forEach { (key, value) ->
+            add("--label")
+            add("$key=$value")
+        }
+
+        name?.let { add(it) }
+    }
+
+    override suspend fun execute(): String {
+        return executeRaw().stdout.trim()
+    }
+
+    override fun executeBlocking(): String {
+        return executeRawBlocking().stdout.trim()
+    }
+
+    companion object {
+        @JvmStatic
+        fun builder(): VolumeCreateCommand = VolumeCreateCommand()
+    }
+}

--- a/docker-kotlin-core/src/main/kotlin/io/github/joshrotenberg/dockerkotlin/core/command/volume/VolumeInspectCommand.kt
+++ b/docker-kotlin-core/src/main/kotlin/io/github/joshrotenberg/dockerkotlin/core/command/volume/VolumeInspectCommand.kt
@@ -1,0 +1,55 @@
+package io.github.joshrotenberg.dockerkotlin.core.command.volume
+
+import io.github.joshrotenberg.dockerkotlin.core.CommandExecutor
+import io.github.joshrotenberg.dockerkotlin.core.command.AbstractDockerCommand
+
+/**
+ * Command to display detailed information on one or more volumes.
+ *
+ * Equivalent to `docker volume inspect`.
+ *
+ * Example usage:
+ * ```kotlin
+ * VolumeInspectCommand("my-volume").executeBlocking()
+ * VolumeInspectCommand("my-volume").format("{{.Mountpoint}}").executeBlocking()
+ * ```
+ */
+class VolumeInspectCommand : AbstractDockerCommand<String> {
+
+    private val volumes: List<String>
+    private var format: String? = null
+
+    constructor(volume: String, executor: CommandExecutor = CommandExecutor()) : super(executor) {
+        this.volumes = listOf(volume)
+    }
+
+    constructor(volumes: List<String>, executor: CommandExecutor = CommandExecutor()) : super(executor) {
+        this.volumes = volumes
+    }
+
+    /** Set output format using Go template. */
+    fun format(format: String) = apply { this.format = format }
+
+    override fun buildArgs(): List<String> = buildList {
+        add("volume")
+        add("inspect")
+        format?.let { add("--format"); add(it) }
+        addAll(volumes)
+    }
+
+    override suspend fun execute(): String {
+        return executeRaw().stdout
+    }
+
+    override fun executeBlocking(): String {
+        return executeRawBlocking().stdout
+    }
+
+    companion object {
+        @JvmStatic
+        fun builder(volume: String): VolumeInspectCommand = VolumeInspectCommand(volume)
+
+        @JvmStatic
+        fun builder(volumes: List<String>): VolumeInspectCommand = VolumeInspectCommand(volumes)
+    }
+}

--- a/docker-kotlin-core/src/main/kotlin/io/github/joshrotenberg/dockerkotlin/core/command/volume/VolumeLsCommand.kt
+++ b/docker-kotlin-core/src/main/kotlin/io/github/joshrotenberg/dockerkotlin/core/command/volume/VolumeLsCommand.kt
@@ -1,0 +1,75 @@
+package io.github.joshrotenberg.dockerkotlin.core.command.volume
+
+import io.github.joshrotenberg.dockerkotlin.core.CommandExecutor
+import io.github.joshrotenberg.dockerkotlin.core.command.AbstractDockerCommand
+
+/**
+ * Command to list Docker volumes.
+ *
+ * Equivalent to `docker volume ls`.
+ *
+ * Example usage:
+ * ```kotlin
+ * VolumeLsCommand()
+ *     .driverFilter("local")
+ *     .executeBlocking()
+ * ```
+ */
+class VolumeLsCommand(
+    executor: CommandExecutor = CommandExecutor()
+) : AbstractDockerCommand<String>(executor) {
+
+    private val filters = mutableMapOf<String, String>()
+    private var format: String? = null
+    private var quiet = false
+
+    /** Add a filter. */
+    fun filter(key: String, value: String) = apply { filters[key] = value }
+
+    /** Filter by driver. */
+    fun driverFilter(driver: String) = apply { filter("driver", driver) }
+
+    /** Filter by label. */
+    fun labelFilter(label: String) = apply { filter("label", label) }
+
+    /** Filter by name. */
+    fun nameFilter(name: String) = apply { filter("name", name) }
+
+    /** Filter dangling volumes. */
+    fun danglingFilter(dangling: Boolean = true) = apply { filter("dangling", dangling.toString()) }
+
+    /** Set output format. */
+    fun format(format: String) = apply { this.format = format }
+
+    /** Format output as JSON. */
+    fun formatJson() = apply { format = "json" }
+
+    /** Only display volume names. */
+    fun quiet() = apply { quiet = true }
+
+    override fun buildArgs(): List<String> = buildList {
+        add("volume")
+        add("ls")
+
+        filters.forEach { (key, value) ->
+            add("--filter")
+            add("$key=$value")
+        }
+
+        format?.let { add("--format"); add(it) }
+        if (quiet) add("--quiet")
+    }
+
+    override suspend fun execute(): String {
+        return executeRaw().stdout
+    }
+
+    override fun executeBlocking(): String {
+        return executeRawBlocking().stdout
+    }
+
+    companion object {
+        @JvmStatic
+        fun builder(): VolumeLsCommand = VolumeLsCommand()
+    }
+}

--- a/docker-kotlin-core/src/main/kotlin/io/github/joshrotenberg/dockerkotlin/core/command/volume/VolumePruneCommand.kt
+++ b/docker-kotlin-core/src/main/kotlin/io/github/joshrotenberg/dockerkotlin/core/command/volume/VolumePruneCommand.kt
@@ -1,0 +1,63 @@
+package io.github.joshrotenberg.dockerkotlin.core.command.volume
+
+import io.github.joshrotenberg.dockerkotlin.core.CommandExecutor
+import io.github.joshrotenberg.dockerkotlin.core.command.AbstractDockerCommand
+
+/**
+ * Command to remove all unused local volumes.
+ *
+ * Equivalent to `docker volume prune`.
+ *
+ * Example usage:
+ * ```kotlin
+ * VolumePruneCommand().force().executeBlocking()
+ * VolumePruneCommand().all().force().executeBlocking()
+ * ```
+ */
+class VolumePruneCommand(
+    executor: CommandExecutor = CommandExecutor()
+) : AbstractDockerCommand<String>(executor) {
+
+    private var all = false
+    private val filters = mutableMapOf<String, String>()
+    private var force = false
+
+    /** Remove all unused volumes, not just anonymous ones. */
+    fun all() = apply { all = true }
+
+    /** Add a filter. */
+    fun filter(key: String, value: String) = apply { filters[key] = value }
+
+    /** Filter by label. */
+    fun labelFilter(label: String) = apply { filter("label", label) }
+
+    /** Do not prompt for confirmation. */
+    fun force() = apply { force = true }
+
+    override fun buildArgs(): List<String> = buildList {
+        add("volume")
+        add("prune")
+
+        if (all) add("--all")
+
+        filters.forEach { (key, value) ->
+            add("--filter")
+            add("$key=$value")
+        }
+
+        if (force) add("--force")
+    }
+
+    override suspend fun execute(): String {
+        return executeRaw().stdout
+    }
+
+    override fun executeBlocking(): String {
+        return executeRawBlocking().stdout
+    }
+
+    companion object {
+        @JvmStatic
+        fun builder(): VolumePruneCommand = VolumePruneCommand()
+    }
+}

--- a/docker-kotlin-core/src/main/kotlin/io/github/joshrotenberg/dockerkotlin/core/command/volume/VolumeRmCommand.kt
+++ b/docker-kotlin-core/src/main/kotlin/io/github/joshrotenberg/dockerkotlin/core/command/volume/VolumeRmCommand.kt
@@ -1,0 +1,55 @@
+package io.github.joshrotenberg.dockerkotlin.core.command.volume
+
+import io.github.joshrotenberg.dockerkotlin.core.CommandExecutor
+import io.github.joshrotenberg.dockerkotlin.core.command.AbstractDockerCommand
+
+/**
+ * Command to remove one or more Docker volumes.
+ *
+ * Equivalent to `docker volume rm`.
+ *
+ * Example usage:
+ * ```kotlin
+ * VolumeRmCommand("my-volume").executeBlocking()
+ * VolumeRmCommand(listOf("vol1", "vol2")).force().executeBlocking()
+ * ```
+ */
+class VolumeRmCommand : AbstractDockerCommand<String> {
+
+    private val volumes: List<String>
+    private var force = false
+
+    constructor(volume: String, executor: CommandExecutor = CommandExecutor()) : super(executor) {
+        this.volumes = listOf(volume)
+    }
+
+    constructor(volumes: List<String>, executor: CommandExecutor = CommandExecutor()) : super(executor) {
+        this.volumes = volumes
+    }
+
+    /** Force removal. */
+    fun force() = apply { force = true }
+
+    override fun buildArgs(): List<String> = buildList {
+        add("volume")
+        add("rm")
+        if (force) add("--force")
+        addAll(volumes)
+    }
+
+    override suspend fun execute(): String {
+        return executeRaw().stdout
+    }
+
+    override fun executeBlocking(): String {
+        return executeRawBlocking().stdout
+    }
+
+    companion object {
+        @JvmStatic
+        fun builder(volume: String): VolumeRmCommand = VolumeRmCommand(volume)
+
+        @JvmStatic
+        fun builder(volumes: List<String>): VolumeRmCommand = VolumeRmCommand(volumes)
+    }
+}

--- a/docker-kotlin-core/src/test/kotlin/io/github/joshrotenberg/dockerkotlin/core/command/AuthCommandsTest.kt
+++ b/docker-kotlin-core/src/test/kotlin/io/github/joshrotenberg/dockerkotlin/core/command/AuthCommandsTest.kt
@@ -1,0 +1,70 @@
+package io.github.joshrotenberg.dockerkotlin.core.command
+
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * Unit tests for auth command argument building.
+ */
+class AuthCommandsTest {
+
+    @Test
+    fun `LoginCommand buildArgs basic`() {
+        val cmd = LoginCommand("testuser", "testpass")
+        val args = cmd.buildArgs()
+        assertEquals("login", args[0])
+        assertTrue(args.contains("--username"))
+        assertTrue(args.contains("testuser"))
+        assertTrue(args.contains("--password"))
+        assertTrue(args.contains("testpass"))
+    }
+
+    @Test
+    fun `LoginCommand buildArgs with registry`() {
+        val cmd = LoginCommand("user", "pass")
+            .registry("gcr.io")
+
+        val args = cmd.buildArgs()
+        assertTrue(args.contains("gcr.io"))
+    }
+
+    @Test
+    fun `LoginCommand buildArgs with password stdin`() {
+        val cmd = LoginCommand("user", "ignored")
+            .passwordStdin()
+
+        val args = cmd.buildArgs()
+        assertTrue(args.contains("--password-stdin"))
+        assertTrue(!args.contains("--password") || args.indexOf("--password-stdin") < args.size)
+    }
+
+    @Test
+    fun `LoginCommand buildArgs with private registry`() {
+        val cmd = LoginCommand("admin", "secret")
+            .registry("my-registry.example.com:5000")
+
+        val args = cmd.buildArgs()
+        assertTrue(args.contains("my-registry.example.com:5000"))
+    }
+
+    @Test
+    fun `LogoutCommand buildArgs basic`() {
+        val cmd = LogoutCommand()
+        assertEquals(listOf("logout"), cmd.buildArgs())
+    }
+
+    @Test
+    fun `LogoutCommand buildArgs with server`() {
+        val cmd = LogoutCommand().server("gcr.io")
+        val args = cmd.buildArgs()
+        assertEquals(listOf("logout", "gcr.io"), args)
+    }
+
+    @Test
+    fun `LogoutCommand buildArgs with private registry`() {
+        val cmd = LogoutCommand().server("my-registry.example.com:5000")
+        val args = cmd.buildArgs()
+        assertTrue(args.contains("my-registry.example.com:5000"))
+    }
+}

--- a/docker-kotlin-core/src/test/kotlin/io/github/joshrotenberg/dockerkotlin/core/command/ImagePruneCommandTest.kt
+++ b/docker-kotlin-core/src/test/kotlin/io/github/joshrotenberg/dockerkotlin/core/command/ImagePruneCommandTest.kt
@@ -1,0 +1,70 @@
+package io.github.joshrotenberg.dockerkotlin.core.command
+
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * Unit tests for ImagePruneCommand argument building.
+ */
+class ImagePruneCommandTest {
+
+    @Test
+    fun `ImagePruneCommand buildArgs basic`() {
+        val cmd = ImagePruneCommand()
+        assertEquals(listOf("image", "prune"), cmd.buildArgs())
+    }
+
+    @Test
+    fun `ImagePruneCommand buildArgs with force`() {
+        val cmd = ImagePruneCommand().force()
+        val args = cmd.buildArgs()
+        assertTrue(args.contains("--force"))
+    }
+
+    @Test
+    fun `ImagePruneCommand buildArgs with all`() {
+        val cmd = ImagePruneCommand().all()
+        val args = cmd.buildArgs()
+        assertTrue(args.contains("--all"))
+    }
+
+    @Test
+    fun `ImagePruneCommand buildArgs with until`() {
+        val cmd = ImagePruneCommand().until("24h")
+        val args = cmd.buildArgs()
+        assertTrue(args.contains("--filter"))
+        assertTrue(args.any { it.contains("until=24h") })
+    }
+
+    @Test
+    fun `ImagePruneCommand buildArgs with label filter`() {
+        val cmd = ImagePruneCommand().labelFilter("deprecated")
+        val args = cmd.buildArgs()
+        assertTrue(args.contains("--filter"))
+        assertTrue(args.any { it.contains("label=deprecated") })
+    }
+
+    @Test
+    fun `ImagePruneCommand buildArgs dangling only`() {
+        val cmd = ImagePruneCommand().danglingOnly().force()
+        val args = cmd.buildArgs()
+        assertTrue(args.contains("--force"))
+        assertTrue(args.any { it.contains("dangling=true") })
+    }
+
+    @Test
+    fun `ImagePruneCommand buildArgs all options`() {
+        val cmd = ImagePruneCommand()
+            .all()
+            .force()
+            .until("7d")
+            .labelFilter("env=test")
+
+        val args = cmd.buildArgs()
+        assertTrue(args.contains("--all"))
+        assertTrue(args.contains("--force"))
+        assertTrue(args.any { it.contains("until=7d") })
+        assertTrue(args.any { it.contains("label=env=test") })
+    }
+}

--- a/docker-kotlin-core/src/test/kotlin/io/github/joshrotenberg/dockerkotlin/core/command/network/NetworkCommandsTest.kt
+++ b/docker-kotlin-core/src/test/kotlin/io/github/joshrotenberg/dockerkotlin/core/command/network/NetworkCommandsTest.kt
@@ -1,0 +1,216 @@
+package io.github.joshrotenberg.dockerkotlin.core.command.network
+
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * Unit tests for network command argument building.
+ */
+class NetworkCommandsTest {
+
+    @Test
+    fun `NetworkCreateCommand buildArgs basic`() {
+        val cmd = NetworkCreateCommand("my-network")
+        assertEquals(listOf("network", "create", "my-network"), cmd.buildArgs())
+    }
+
+    @Test
+    fun `NetworkCreateCommand buildArgs with driver`() {
+        val cmd = NetworkCreateCommand("my-network")
+            .driver("overlay")
+
+        val args = cmd.buildArgs()
+        assertTrue(args.contains("--driver"))
+        assertTrue(args.contains("overlay"))
+    }
+
+    @Test
+    fun `NetworkCreateCommand buildArgs with subnet and gateway`() {
+        val cmd = NetworkCreateCommand("my-network")
+            .subnet("172.20.0.0/16")
+            .gateway("172.20.0.1")
+
+        val args = cmd.buildArgs()
+        assertTrue(args.contains("--subnet"))
+        assertTrue(args.contains("172.20.0.0/16"))
+        assertTrue(args.contains("--gateway"))
+        assertTrue(args.contains("172.20.0.1"))
+    }
+
+    @Test
+    fun `NetworkCreateCommand buildArgs with all options`() {
+        val cmd = NetworkCreateCommand("my-network")
+            .driver("bridge")
+            .driverOpt("com.docker.network.bridge.name", "br0")
+            .subnet("172.20.0.0/16")
+            .ipRange("172.20.240.0/20")
+            .gateway("172.20.0.1")
+            .ipv6()
+            .attachable()
+            .internal()
+            .label("env", "test")
+            .auxAddress("host1", "172.20.0.5")
+
+        val args = cmd.buildArgs()
+        assertTrue(args.contains("--driver"))
+        assertTrue(args.contains("--ipv6"))
+        assertTrue(args.contains("--attachable"))
+        assertTrue(args.contains("--internal"))
+        assertTrue(args.contains("--label"))
+        assertTrue(args.contains("env=test"))
+    }
+
+    @Test
+    fun `NetworkLsCommand buildArgs basic`() {
+        val cmd = NetworkLsCommand()
+        assertEquals(listOf("network", "ls"), cmd.buildArgs())
+    }
+
+    @Test
+    fun `NetworkLsCommand buildArgs with filters`() {
+        val cmd = NetworkLsCommand()
+            .driverFilter("bridge")
+            .nameFilter("my-network")
+
+        val args = cmd.buildArgs()
+        assertTrue(args.contains("--filter"))
+        assertTrue(args.any { it.contains("driver=bridge") })
+        assertTrue(args.any { it.contains("name=my-network") })
+    }
+
+    @Test
+    fun `NetworkLsCommand buildArgs with format`() {
+        val cmd = NetworkLsCommand().formatJson()
+        val args = cmd.buildArgs()
+        assertTrue(args.contains("--format"))
+        assertTrue(args.contains("json"))
+    }
+
+    @Test
+    fun `NetworkLsCommand buildArgs quiet`() {
+        val cmd = NetworkLsCommand().quiet()
+        val args = cmd.buildArgs()
+        assertTrue(args.contains("--quiet"))
+    }
+
+    @Test
+    fun `NetworkRmCommand buildArgs single`() {
+        val cmd = NetworkRmCommand("my-network")
+        assertEquals(listOf("network", "rm", "my-network"), cmd.buildArgs())
+    }
+
+    @Test
+    fun `NetworkRmCommand buildArgs multiple`() {
+        val cmd = NetworkRmCommand(listOf("net1", "net2"))
+        val args = cmd.buildArgs()
+        assertEquals("network", args[0])
+        assertEquals("rm", args[1])
+        assertTrue(args.contains("net1"))
+        assertTrue(args.contains("net2"))
+    }
+
+    @Test
+    fun `NetworkRmCommand buildArgs with force`() {
+        val cmd = NetworkRmCommand("my-network").force()
+        val args = cmd.buildArgs()
+        assertTrue(args.contains("--force"))
+    }
+
+    @Test
+    fun `NetworkInspectCommand buildArgs single`() {
+        val cmd = NetworkInspectCommand("my-network")
+        assertEquals(listOf("network", "inspect", "my-network"), cmd.buildArgs())
+    }
+
+    @Test
+    fun `NetworkInspectCommand buildArgs multiple`() {
+        val cmd = NetworkInspectCommand(listOf("net1", "net2"))
+        val args = cmd.buildArgs()
+        assertTrue(args.contains("net1"))
+        assertTrue(args.contains("net2"))
+    }
+
+    @Test
+    fun `NetworkInspectCommand buildArgs with format`() {
+        val cmd = NetworkInspectCommand("my-network")
+            .format("{{.Driver}}")
+
+        val args = cmd.buildArgs()
+        assertTrue(args.contains("--format"))
+        assertTrue(args.contains("{{.Driver}}"))
+    }
+
+    @Test
+    fun `NetworkInspectCommand buildArgs verbose`() {
+        val cmd = NetworkInspectCommand("my-network").verbose()
+        val args = cmd.buildArgs()
+        assertTrue(args.contains("--verbose"))
+    }
+
+    @Test
+    fun `NetworkConnectCommand buildArgs basic`() {
+        val cmd = NetworkConnectCommand("my-network", "my-container")
+        assertEquals(listOf("network", "connect", "my-network", "my-container"), cmd.buildArgs())
+    }
+
+    @Test
+    fun `NetworkConnectCommand buildArgs with ip`() {
+        val cmd = NetworkConnectCommand("my-network", "my-container")
+            .ipv4("172.20.0.10")
+
+        val args = cmd.buildArgs()
+        assertTrue(args.contains("--ip"))
+        assertTrue(args.contains("172.20.0.10"))
+    }
+
+    @Test
+    fun `NetworkConnectCommand buildArgs with alias`() {
+        val cmd = NetworkConnectCommand("my-network", "my-container")
+            .alias("db")
+            .alias("database")
+
+        val args = cmd.buildArgs()
+        assertEquals(2, args.count { it == "--alias" })
+        assertTrue(args.contains("db"))
+        assertTrue(args.contains("database"))
+    }
+
+    @Test
+    fun `NetworkDisconnectCommand buildArgs basic`() {
+        val cmd = NetworkDisconnectCommand("my-network", "my-container")
+        assertEquals(listOf("network", "disconnect", "my-network", "my-container"), cmd.buildArgs())
+    }
+
+    @Test
+    fun `NetworkDisconnectCommand buildArgs with force`() {
+        val cmd = NetworkDisconnectCommand("my-network", "my-container").force()
+        val args = cmd.buildArgs()
+        assertTrue(args.contains("--force"))
+    }
+
+    @Test
+    fun `NetworkPruneCommand buildArgs basic`() {
+        val cmd = NetworkPruneCommand()
+        assertEquals(listOf("network", "prune"), cmd.buildArgs())
+    }
+
+    @Test
+    fun `NetworkPruneCommand buildArgs with force`() {
+        val cmd = NetworkPruneCommand().force()
+        val args = cmd.buildArgs()
+        assertTrue(args.contains("--force"))
+    }
+
+    @Test
+    fun `NetworkPruneCommand buildArgs with filters`() {
+        val cmd = NetworkPruneCommand()
+            .until("24h")
+            .labelFilter("env=test")
+
+        val args = cmd.buildArgs()
+        assertTrue(args.contains("--filter"))
+        assertTrue(args.any { it.contains("until=24h") })
+        assertTrue(args.any { it.contains("label=env=test") })
+    }
+}

--- a/docker-kotlin-core/src/test/kotlin/io/github/joshrotenberg/dockerkotlin/core/command/system/SystemCommandsTest.kt
+++ b/docker-kotlin-core/src/test/kotlin/io/github/joshrotenberg/dockerkotlin/core/command/system/SystemCommandsTest.kt
@@ -1,0 +1,85 @@
+package io.github.joshrotenberg.dockerkotlin.core.command.system
+
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * Unit tests for system command argument building.
+ */
+class SystemCommandsTest {
+
+    @Test
+    fun `SystemDfCommand buildArgs basic`() {
+        val cmd = SystemDfCommand()
+        assertEquals(listOf("system", "df"), cmd.buildArgs())
+    }
+
+    @Test
+    fun `SystemDfCommand buildArgs verbose`() {
+        val cmd = SystemDfCommand().verbose()
+        val args = cmd.buildArgs()
+        assertTrue(args.contains("--verbose"))
+    }
+
+    @Test
+    fun `SystemDfCommand buildArgs with format`() {
+        val cmd = SystemDfCommand().format("{{.Type}}")
+        val args = cmd.buildArgs()
+        assertTrue(args.contains("--format"))
+        assertTrue(args.contains("{{.Type}}"))
+    }
+
+    @Test
+    fun `SystemDfCommand buildArgs format json`() {
+        val cmd = SystemDfCommand().formatJson()
+        val args = cmd.buildArgs()
+        assertTrue(args.contains("--format"))
+        assertTrue(args.contains("json"))
+    }
+
+    @Test
+    fun `SystemPruneCommand buildArgs basic`() {
+        val cmd = SystemPruneCommand()
+        assertEquals(listOf("system", "prune"), cmd.buildArgs())
+    }
+
+    @Test
+    fun `SystemPruneCommand buildArgs with force`() {
+        val cmd = SystemPruneCommand().force()
+        val args = cmd.buildArgs()
+        assertTrue(args.contains("--force"))
+    }
+
+    @Test
+    fun `SystemPruneCommand buildArgs with all`() {
+        val cmd = SystemPruneCommand().all()
+        val args = cmd.buildArgs()
+        assertTrue(args.contains("--all"))
+    }
+
+    @Test
+    fun `SystemPruneCommand buildArgs with volumes`() {
+        val cmd = SystemPruneCommand().volumes()
+        val args = cmd.buildArgs()
+        assertTrue(args.contains("--volumes"))
+    }
+
+    @Test
+    fun `SystemPruneCommand buildArgs with all options`() {
+        val cmd = SystemPruneCommand()
+            .all()
+            .volumes()
+            .force()
+            .until("24h")
+            .labelFilter("env=test")
+
+        val args = cmd.buildArgs()
+        assertTrue(args.contains("--all"))
+        assertTrue(args.contains("--volumes"))
+        assertTrue(args.contains("--force"))
+        assertTrue(args.contains("--filter"))
+        assertTrue(args.any { it.contains("until=24h") })
+        assertTrue(args.any { it.contains("label=env=test") })
+    }
+}

--- a/docker-kotlin-core/src/test/kotlin/io/github/joshrotenberg/dockerkotlin/core/command/volume/VolumeCommandsTest.kt
+++ b/docker-kotlin-core/src/test/kotlin/io/github/joshrotenberg/dockerkotlin/core/command/volume/VolumeCommandsTest.kt
@@ -1,0 +1,176 @@
+package io.github.joshrotenberg.dockerkotlin.core.command.volume
+
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * Unit tests for volume command argument building.
+ */
+class VolumeCommandsTest {
+
+    @Test
+    fun `VolumeCreateCommand buildArgs basic`() {
+        val cmd = VolumeCreateCommand()
+        assertEquals(listOf("volume", "create"), cmd.buildArgs())
+    }
+
+    @Test
+    fun `VolumeCreateCommand buildArgs with name`() {
+        val cmd = VolumeCreateCommand().name("my-volume")
+        assertEquals(listOf("volume", "create", "my-volume"), cmd.buildArgs())
+    }
+
+    @Test
+    fun `VolumeCreateCommand buildArgs with driver`() {
+        val cmd = VolumeCreateCommand()
+            .name("my-volume")
+            .driver("local")
+
+        val args = cmd.buildArgs()
+        assertTrue(args.contains("--driver"))
+        assertTrue(args.contains("local"))
+    }
+
+    @Test
+    fun `VolumeCreateCommand buildArgs with driver opts`() {
+        val cmd = VolumeCreateCommand()
+            .name("my-volume")
+            .driverOpt("type", "nfs")
+            .driverOpt("o", "addr=10.0.0.1")
+
+        val args = cmd.buildArgs()
+        assertTrue(args.contains("--opt"))
+        assertTrue(args.any { it.contains("type=nfs") })
+        assertTrue(args.any { it.contains("o=addr=10.0.0.1") })
+    }
+
+    @Test
+    fun `VolumeCreateCommand buildArgs with labels`() {
+        val cmd = VolumeCreateCommand()
+            .name("my-volume")
+            .label("env", "production")
+
+        val args = cmd.buildArgs()
+        assertTrue(args.contains("--label"))
+        assertTrue(args.any { it.contains("env=production") })
+    }
+
+    @Test
+    fun `VolumeLsCommand buildArgs basic`() {
+        val cmd = VolumeLsCommand()
+        assertEquals(listOf("volume", "ls"), cmd.buildArgs())
+    }
+
+    @Test
+    fun `VolumeLsCommand buildArgs with filters`() {
+        val cmd = VolumeLsCommand()
+            .driverFilter("local")
+            .nameFilter("my-vol")
+
+        val args = cmd.buildArgs()
+        assertTrue(args.contains("--filter"))
+        assertTrue(args.any { it.contains("driver=local") })
+        assertTrue(args.any { it.contains("name=my-vol") })
+    }
+
+    @Test
+    fun `VolumeLsCommand buildArgs quiet`() {
+        val cmd = VolumeLsCommand().quiet()
+        val args = cmd.buildArgs()
+        assertTrue(args.contains("--quiet"))
+    }
+
+    @Test
+    fun `VolumeLsCommand buildArgs format json`() {
+        val cmd = VolumeLsCommand().formatJson()
+        val args = cmd.buildArgs()
+        assertTrue(args.contains("--format"))
+        assertTrue(args.contains("json"))
+    }
+
+    @Test
+    fun `VolumeLsCommand buildArgs dangling filter`() {
+        val cmd = VolumeLsCommand().danglingFilter()
+        val args = cmd.buildArgs()
+        assertTrue(args.any { it.contains("dangling=true") })
+    }
+
+    @Test
+    fun `VolumeRmCommand buildArgs single`() {
+        val cmd = VolumeRmCommand("my-volume")
+        assertEquals(listOf("volume", "rm", "my-volume"), cmd.buildArgs())
+    }
+
+    @Test
+    fun `VolumeRmCommand buildArgs multiple`() {
+        val cmd = VolumeRmCommand(listOf("vol1", "vol2"))
+        val args = cmd.buildArgs()
+        assertEquals("volume", args[0])
+        assertEquals("rm", args[1])
+        assertTrue(args.contains("vol1"))
+        assertTrue(args.contains("vol2"))
+    }
+
+    @Test
+    fun `VolumeRmCommand buildArgs with force`() {
+        val cmd = VolumeRmCommand("my-volume").force()
+        val args = cmd.buildArgs()
+        assertTrue(args.contains("--force"))
+    }
+
+    @Test
+    fun `VolumeInspectCommand buildArgs single`() {
+        val cmd = VolumeInspectCommand("my-volume")
+        assertEquals(listOf("volume", "inspect", "my-volume"), cmd.buildArgs())
+    }
+
+    @Test
+    fun `VolumeInspectCommand buildArgs multiple`() {
+        val cmd = VolumeInspectCommand(listOf("vol1", "vol2"))
+        val args = cmd.buildArgs()
+        assertTrue(args.contains("vol1"))
+        assertTrue(args.contains("vol2"))
+    }
+
+    @Test
+    fun `VolumeInspectCommand buildArgs with format`() {
+        val cmd = VolumeInspectCommand("my-volume")
+            .format("{{.Mountpoint}}")
+
+        val args = cmd.buildArgs()
+        assertTrue(args.contains("--format"))
+        assertTrue(args.contains("{{.Mountpoint}}"))
+    }
+
+    @Test
+    fun `VolumePruneCommand buildArgs basic`() {
+        val cmd = VolumePruneCommand()
+        assertEquals(listOf("volume", "prune"), cmd.buildArgs())
+    }
+
+    @Test
+    fun `VolumePruneCommand buildArgs with force`() {
+        val cmd = VolumePruneCommand().force()
+        val args = cmd.buildArgs()
+        assertTrue(args.contains("--force"))
+    }
+
+    @Test
+    fun `VolumePruneCommand buildArgs with all`() {
+        val cmd = VolumePruneCommand().all()
+        val args = cmd.buildArgs()
+        assertTrue(args.contains("--all"))
+    }
+
+    @Test
+    fun `VolumePruneCommand buildArgs with filters`() {
+        val cmd = VolumePruneCommand()
+            .labelFilter("env=test")
+            .force()
+
+        val args = cmd.buildArgs()
+        assertTrue(args.contains("--filter"))
+        assertTrue(args.any { it.contains("label=env=test") })
+    }
+}

--- a/docs/compose/dsl.md
+++ b/docs/compose/dsl.md
@@ -1,0 +1,737 @@
+# Compose DSL
+
+The Compose DSL provides a type-safe way to define Docker Compose configurations directly in Kotlin or Java code. This is particularly powerful for integration testing, where you can define your test infrastructure alongside your test code.
+
+## Quick Start
+
+=== "Kotlin"
+
+    ```kotlin
+    import io.github.joshrotenberg.dockerkotlin.compose.dsl.*
+
+    val compose = dockerCompose {
+        service("redis") {
+            image = "redis:7-alpine"
+            ports("6379:6379")
+        }
+    }
+
+    // Generate YAML
+    println(compose.toYaml())
+
+    // Or run directly
+    compose.upBlocking { detach() }
+    ```
+
+=== "Java"
+
+    ```java
+    import io.github.joshrotenberg.dockerkotlin.compose.dsl.*;
+
+    ComposeSpec compose = ComposeBuilder.create()
+        .service("redis", redis -> redis
+            .image("redis:7-alpine")
+            .ports("6379:6379"))
+        .build();
+
+    // Generate YAML
+    System.out.println(compose.toYaml());
+    ```
+
+## Service Configuration
+
+### Basic Service
+
+=== "Kotlin"
+
+    ```kotlin
+    service("web") {
+        image = "nginx:alpine"
+        containerName = "my-nginx"
+        ports("8080:80", "8443:443")
+        restart = "unless-stopped"
+    }
+    ```
+
+=== "Java"
+
+    ```java
+    .service("web", web -> web
+        .image("nginx:alpine")
+        .containerName("my-nginx")
+        .ports("8080:80", "8443:443")
+        .restart("unless-stopped"))
+    ```
+
+### Environment Variables
+
+=== "Kotlin"
+
+    ```kotlin
+    service("api") {
+        image = "myapp/api:latest"
+        environment {
+            "NODE_ENV" to "production"
+            "PORT" to 3000
+            "DEBUG" to false
+        }
+        // Or individually
+        environment("DATABASE_URL", "postgres://db:5432/app")
+    }
+    ```
+
+=== "Java"
+
+    ```java
+    .service("api", api -> api
+        .image("myapp/api:latest")
+        .environment("NODE_ENV", "production")
+        .environment("PORT", "3000")
+        .environment("DATABASE_URL", "postgres://db:5432/app"))
+    ```
+
+### Volumes
+
+=== "Kotlin"
+
+    ```kotlin
+    service("db") {
+        image = "postgres:16"
+        // Named volume
+        volume("pgdata", "/var/lib/postgresql/data")
+        // Bind mount
+        volume("./init", "/docker-entrypoint-initdb.d", "ro")
+        // Short syntax
+        volumes("./config:/etc/app/config:ro")
+    }
+
+    // Define named volume
+    volume("pgdata") {
+        driver = "local"
+    }
+    ```
+
+=== "Java"
+
+    ```java
+    .service("db", db -> db
+        .image("postgres:16")
+        .volume("pgdata", "/var/lib/postgresql/data")
+        .volume("./init", "/docker-entrypoint-initdb.d", "ro"))
+    .volume("pgdata", vol -> vol.driver("local"))
+    ```
+
+### Networks
+
+=== "Kotlin"
+
+    ```kotlin
+    service("api") {
+        image = "myapp/api:latest"
+        networks("frontend", "backend")
+    }
+
+    network("frontend") {
+        driver = "bridge"
+    }
+
+    network("backend") {
+        driver = "bridge"
+        internal = true  // No external access
+    }
+    ```
+
+=== "Java"
+
+    ```java
+    .service("api", api -> api
+        .image("myapp/api:latest")
+        .networks("frontend", "backend"))
+    .network("frontend", net -> net.driver("bridge"))
+    .network("backend", net -> net
+        .driver("bridge")
+        .internal(true))
+    ```
+
+### Dependencies
+
+=== "Kotlin"
+
+    ```kotlin
+    // Simple dependencies
+    service("web") {
+        image = "nginx:alpine"
+        dependsOn("api", "redis")
+    }
+
+    // With conditions
+    service("web") {
+        image = "nginx:alpine"
+        dependsOn {
+            serviceHealthy("api")    // Wait for healthcheck
+            serviceStarted("redis")  // Just wait for start
+        }
+    }
+    ```
+
+=== "Java"
+
+    ```java
+    .service("web", web -> web
+        .image("nginx:alpine")
+        .dependsOn("api", "redis"))
+    ```
+
+### Healthcheck
+
+=== "Kotlin"
+
+    ```kotlin
+    service("api") {
+        image = "myapp/api:latest"
+        healthcheck {
+            testShell("curl -f http://localhost:3000/health || exit 1")
+            interval = "30s"
+            timeout = "10s"
+            retries = 3
+            startPeriod = "5s"
+        }
+    }
+
+    // Or with CMD form
+    service("db") {
+        image = "postgres:16"
+        healthcheck {
+            testCmd("pg_isready", "-U", "postgres")
+            interval = "10s"
+            retries = 5
+        }
+    }
+    ```
+
+=== "Java"
+
+    ```java
+    .service("api", api -> api
+        .image("myapp/api:latest")
+        .healthcheck(hc -> hc
+            .testShell("curl -f http://localhost:3000/health || exit 1")
+            .interval("30s")
+            .timeout("10s")
+            .retries(3)
+            .startPeriod("5s")))
+    ```
+
+### Build Configuration
+
+=== "Kotlin"
+
+    ```kotlin
+    service("app") {
+        build("./app") {
+            dockerfile = "Dockerfile.prod"
+            target = "production"
+            arg("VERSION", "1.0.0")
+            arg("BUILD_DATE", System.getenv("BUILD_DATE") ?: "unknown")
+            cacheFrom("myapp:latest")
+        }
+    }
+    ```
+
+=== "Java"
+
+    ```java
+    .service("app", app -> app
+        .build("./app", build -> build
+            .dockerfile("Dockerfile.prod")
+            .target("production")
+            .arg("VERSION", "1.0.0")))
+    ```
+
+### Deploy (Swarm Mode)
+
+=== "Kotlin"
+
+    ```kotlin
+    service("api") {
+        image = "myapp/api:latest"
+        deploy {
+            replicas = 3
+            resources {
+                limits {
+                    cpus = "0.5"
+                    memory = "512M"
+                }
+                reservations {
+                    cpus = "0.25"
+                    memory = "256M"
+                }
+            }
+            restartPolicy {
+                condition = "on-failure"
+                maxAttempts = 3
+                delay = "5s"
+            }
+        }
+    }
+    ```
+
+=== "Java"
+
+    ```java
+    .service("api", api -> api
+        .image("myapp/api:latest")
+        .deploy(deploy -> deploy
+            .replicas(3)
+            .resources(res -> res
+                .cpus("0.5")
+                .memory("512M"))))
+    ```
+
+### Logging
+
+=== "Kotlin"
+
+    ```kotlin
+    service("app") {
+        image = "myapp:latest"
+        logging("json-file") {
+            maxSize("50m")
+            maxFile(5)
+            option("compress", "true")
+        }
+    }
+    ```
+
+=== "Java"
+
+    ```java
+    .service("app", app -> app
+        .image("myapp:latest")
+        .logging("json-file", log -> log
+            .maxSize("50m")
+            .maxFile(5)))
+    ```
+
+## Running Compose Stacks
+
+### Generate YAML Only
+
+```kotlin
+val compose = dockerCompose {
+    service("redis") { image = "redis:7" }
+}
+
+// Get YAML string
+val yaml = compose.toYaml()
+
+// Write to file
+compose.writeTo("docker-compose.yml")
+compose.writeTo(File("docker-compose.yml"))
+```
+
+### Run with Commands
+
+```kotlin
+val compose = dockerCompose {
+    service("redis") { image = "redis:7" }
+}
+
+// Start the stack
+compose.upBlocking {
+    detach()
+    wait()  // Wait for healthchecks
+}
+
+// Stop the stack
+compose.downBlocking {
+    volumes()  // Also remove volumes
+}
+```
+
+### Automatic Cleanup with use()
+
+```kotlin
+dockerCompose {
+    service("redis") { image = "redis:7-alpine" }
+}.use("my-test-stack") {
+    // Stack is running here
+    // Do your testing...
+}
+// Stack is automatically stopped and cleaned up
+```
+
+## Testing Examples
+
+### JUnit 5 Integration Test
+
+=== "Kotlin"
+
+    ```kotlin
+    import io.github.joshrotenberg.dockerkotlin.compose.dsl.*
+    import org.junit.jupiter.api.*
+
+    class UserServiceIntegrationTest {
+
+        companion object {
+            private val testStack = dockerCompose {
+                service("postgres") {
+                    image = "postgres:16-alpine"
+                    environment {
+                        "POSTGRES_USER" to "test"
+                        "POSTGRES_PASSWORD" to "test"
+                        "POSTGRES_DB" to "testdb"
+                    }
+                    ports("5432:5432")
+                    healthcheck {
+                        testCmd("pg_isready", "-U", "test")
+                        interval = "5s"
+                        retries = 5
+                    }
+                }
+
+                service("redis") {
+                    image = "redis:7-alpine"
+                    ports("6379:6379")
+                    healthcheck {
+                        testCmd("redis-cli", "ping")
+                        interval = "5s"
+                        retries = 3
+                    }
+                }
+            }
+
+            @BeforeAll
+            @JvmStatic
+            fun startContainers() {
+                testStack.upBlocking {
+                    detach()
+                    wait()  // Wait for healthchecks to pass
+                }
+            }
+
+            @AfterAll
+            @JvmStatic
+            fun stopContainers() {
+                testStack.downBlocking {
+                    volumes()
+                }
+            }
+        }
+
+        @Test
+        fun `user can be created and retrieved`() {
+            // Both postgres and redis are ready
+            val userService = UserService(
+                dbUrl = "jdbc:postgresql://localhost:5432/testdb",
+                redisUrl = "redis://localhost:6379"
+            )
+
+            val user = userService.createUser("test@example.com")
+            assertNotNull(user.id)
+        }
+
+        @Test
+        fun `user is cached in redis`() {
+            // Test caching behavior
+        }
+    }
+    ```
+
+=== "Java"
+
+    ```java
+    import io.github.joshrotenberg.dockerkotlin.compose.dsl.*;
+    import org.junit.jupiter.api.*;
+
+    class UserServiceIntegrationTest {
+
+        private static ComposeSpec testStack;
+
+        @BeforeAll
+        static void startContainers() {
+            testStack = ComposeBuilder.create()
+                .service("postgres", pg -> pg
+                    .image("postgres:16-alpine")
+                    .environment("POSTGRES_USER", "test")
+                    .environment("POSTGRES_PASSWORD", "test")
+                    .environment("POSTGRES_DB", "testdb")
+                    .ports("5432:5432")
+                    .healthcheck(hc -> hc
+                        .testCmd("pg_isready", "-U", "test")
+                        .interval("5s")
+                        .retries(5)))
+                .service("redis", redis -> redis
+                    .image("redis:7-alpine")
+                    .ports("6379:6379")
+                    .healthcheck(hc -> hc
+                        .testCmd("redis-cli", "ping")
+                        .interval("5s")
+                        .retries(3)))
+                .build();
+
+            testStack.runner()
+                .projectName("user-service-test")
+                .up()
+                .detach()
+                .wait()
+                .executeBlocking();
+        }
+
+        @AfterAll
+        static void stopContainers() {
+            testStack.runner()
+                .projectName("user-service-test")
+                .down()
+                .volumes()
+                .executeBlocking();
+        }
+
+        @Test
+        void userCanBeCreatedAndRetrieved() {
+            // Test implementation
+        }
+    }
+    ```
+
+### Per-Test Container Lifecycle
+
+```kotlin
+class IsolatedTest {
+
+    @Test
+    fun `each test gets fresh containers`() {
+        dockerCompose {
+            service("redis") {
+                image = "redis:7-alpine"
+                ports("6379:6379")
+            }
+        }.use("isolated-${UUID.randomUUID()}") {
+            // Fresh Redis for this test only
+            val redis = Jedis("localhost", 6379)
+            redis.set("key", "value")
+            assertEquals("value", redis.get("key"))
+        }
+        // Container cleaned up automatically
+    }
+}
+```
+
+### Reusable Test Fixtures
+
+```kotlin
+object TestContainers {
+    val postgres = dockerCompose {
+        service("postgres") {
+            image = "postgres:16-alpine"
+            environment {
+                "POSTGRES_USER" to "test"
+                "POSTGRES_PASSWORD" to "test"
+                "POSTGRES_DB" to "testdb"
+            }
+            ports("5432:5432")
+            healthcheck {
+                testCmd("pg_isready", "-U", "test")
+                interval = "5s"
+                retries = 5
+            }
+        }
+    }
+
+    val redis = dockerCompose {
+        service("redis") {
+            image = "redis:7-alpine"
+            ports("6379:6379")
+        }
+    }
+
+    val fullStack = dockerCompose {
+        service("postgres") {
+            image = "postgres:16-alpine"
+            environment("POSTGRES_PASSWORD", "test")
+            ports("5432:5432")
+        }
+        service("redis") {
+            image = "redis:7-alpine"
+            ports("6379:6379")
+        }
+        service("rabbitmq") {
+            image = "rabbitmq:3-management-alpine"
+            ports("5672:5672", "15672:15672")
+        }
+    }
+}
+
+// Usage in tests
+class DatabaseTest {
+    companion object {
+        @BeforeAll
+        @JvmStatic
+        fun setup() {
+            TestContainers.postgres.upBlocking { detach(); wait() }
+        }
+
+        @AfterAll
+        @JvmStatic
+        fun teardown() {
+            TestContainers.postgres.downBlocking { volumes() }
+        }
+    }
+}
+```
+
+### Dynamic Configuration
+
+```kotlin
+fun createTestStack(
+    postgresVersion: String = "16",
+    redisVersion: String = "7",
+    enableMonitoring: Boolean = false
+) = dockerCompose {
+    service("postgres") {
+        image = "postgres:$postgresVersion-alpine"
+        environment("POSTGRES_PASSWORD", "test")
+        ports("5432:5432")
+    }
+
+    service("redis") {
+        image = "redis:$redisVersion-alpine"
+        ports("6379:6379")
+    }
+
+    if (enableMonitoring) {
+        service("prometheus") {
+            image = "prom/prometheus:latest"
+            ports("9090:9090")
+            volumes("./prometheus.yml:/etc/prometheus/prometheus.yml:ro")
+        }
+
+        service("grafana") {
+            image = "grafana/grafana:latest"
+            ports("3000:3000")
+            dependsOn("prometheus")
+        }
+    }
+}
+
+// Usage
+val stack = createTestStack(
+    postgresVersion = "15",
+    enableMonitoring = true
+)
+```
+
+## Full Example
+
+```kotlin
+val productionStack = dockerCompose {
+    name = "myapp-production"
+
+    // Frontend
+    service("nginx") {
+        image = "nginx:alpine"
+        ports("80:80", "443:443")
+        volumes(
+            "./nginx/nginx.conf:/etc/nginx/nginx.conf:ro",
+            "./nginx/certs:/etc/nginx/certs:ro"
+        )
+        networks("frontend")
+        dependsOn {
+            serviceHealthy("api")
+        }
+        restart = "unless-stopped"
+        logging("json-file") {
+            maxSize("50m")
+            maxFile(5)
+        }
+    }
+
+    // API
+    service("api") {
+        image = "myapp/api:latest"
+        environment {
+            "NODE_ENV" to "production"
+            "DATABASE_URL" to "postgres://postgres:5432/app"
+            "REDIS_URL" to "redis://redis:6379"
+            "JWT_SECRET" to System.getenv("JWT_SECRET")
+        }
+        networks("frontend", "backend")
+        dependsOn {
+            serviceHealthy("postgres")
+            serviceHealthy("redis")
+        }
+        healthcheck {
+            testShell("curl -f http://localhost:3000/health || exit 1")
+            interval = "30s"
+            timeout = "10s"
+            retries = 3
+            startPeriod = "10s"
+        }
+        deploy {
+            replicas = 2
+            resources {
+                limits {
+                    cpus = "1"
+                    memory = "1G"
+                }
+            }
+            restartPolicy {
+                condition = "on-failure"
+                maxAttempts = 3
+            }
+        }
+    }
+
+    // Database
+    service("postgres") {
+        image = "postgres:16-alpine"
+        environment {
+            "POSTGRES_USER" to "app"
+            "POSTGRES_PASSWORD" to System.getenv("DB_PASSWORD")
+            "POSTGRES_DB" to "app"
+        }
+        volumes("pgdata:/var/lib/postgresql/data")
+        networks("backend")
+        healthcheck {
+            testCmd("pg_isready", "-U", "app")
+            interval = "10s"
+            retries = 5
+        }
+    }
+
+    // Cache
+    service("redis") {
+        image = "redis:7-alpine"
+        command("redis-server", "--appendonly", "yes")
+        volumes("redis-data:/data")
+        networks("backend")
+        healthcheck {
+            testCmd("redis-cli", "ping")
+            interval = "10s"
+            retries = 3
+        }
+    }
+
+    // Networks
+    network("frontend") {
+        driver = "bridge"
+    }
+
+    network("backend") {
+        driver = "bridge"
+        internal = true
+    }
+
+    // Volumes
+    volume("pgdata") {
+        driver = "local"
+    }
+
+    volume("redis-data") {
+        driver = "local"
+    }
+}
+
+// Generate docker-compose.yml
+productionStack.writeTo("docker-compose.prod.yml")
+```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -102,6 +102,7 @@ nav:
   - Compose:
       - Overview: compose/overview.md
       - Commands: compose/commands.md
+      - DSL: compose/dsl.md
   - Templates:
       - Overview: container-templates/overview.md
       - Wait Strategies: container-templates/wait-strategies.md


### PR DESCRIPTION
- Add network commands: create, ls, rm, inspect, connect, disconnect, prune
- Add volume commands: create, ls, rm, inspect, prune
- Add system commands: df, prune
- Add auth commands: login, logout
- Add image prune command
- Add unit tests for all new commands
- Add Compose DSL documentation with testing examples
- Add GitHub Actions CI workflow for build/test on Java 17 and 21
- Add GitHub Actions workflow for docs deployment to GitHub Pages
- Add release workflow for tagged releases
- Add dependabot configuration for gradle, github-actions, and pip