### PR TITLE
chore: migrate to Gradle version catalog

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-    kotlin("jvm") version "2.1.0" apply false
+    alias(libs.plugins.kotlin.jvm) apply false
     `java-library`
     `maven-publish`
 }
@@ -35,18 +35,13 @@ subprojects {
     }
 
     dependencies {
-        val coroutinesVersion = "1.9.0"
-        val slf4jVersion = "2.0.16"
-        val junitVersion = "5.11.4"
+        "implementation"(platform(rootProject.libs.coroutines.bom))
+        "implementation"(rootProject.libs.coroutines.core)
+        "implementation"(rootProject.libs.slf4j.api)
 
-        "implementation"(platform("org.jetbrains.kotlinx:kotlinx-coroutines-bom:$coroutinesVersion"))
-        "implementation"("org.jetbrains.kotlinx:kotlinx-coroutines-core")
-        "implementation"("org.slf4j:slf4j-api:$slf4jVersion")
-
-        "testImplementation"(kotlin("test"))
-        "testImplementation"("org.jetbrains.kotlinx:kotlinx-coroutines-test")
-        "testImplementation"("org.junit.jupiter:junit-jupiter:$junitVersion")
-        "testRuntimeOnly"("org.junit.platform:junit-platform-launcher")
-        "testRuntimeOnly"("ch.qos.logback:logback-classic:1.5.12")
+        "testImplementation"(platform(rootProject.libs.junit.bom))
+        "testImplementation"(rootProject.libs.bundles.testing)
+        "testRuntimeOnly"(rootProject.libs.junit.platform.launcher)
+        "testRuntimeOnly"(rootProject.libs.logback.classic)
     }
 }

--- a/docker-kotlin-compose/build.gradle.kts
+++ b/docker-kotlin-compose/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-    kotlin("jvm")
+    alias(libs.plugins.kotlin.jvm)
     `java-library`
 }
 
@@ -7,15 +7,5 @@ description = "Docker Compose support for docker-kotlin"
 
 dependencies {
     api(project(":docker-kotlin-core"))
-
-    // YAML generation
-    implementation("org.yaml:snakeyaml:2.3")
-
-    // Testing
-    testImplementation(kotlin("test"))
-    testImplementation("org.junit.jupiter:junit-jupiter:5.11.4")
-}
-
-tasks.test {
-    useJUnitPlatform()
+    implementation(libs.snakeyaml)
 }

--- a/docker-kotlin-core/build.gradle.kts
+++ b/docker-kotlin-core/build.gradle.kts
@@ -1,11 +1,11 @@
 plugins {
-    kotlin("jvm")
+    alias(libs.plugins.kotlin.jvm)
     `java-library`
 }
 
 description = "Core Docker CLI wrapper for Kotlin/JVM"
 
 dependencies {
-    api("org.jetbrains.kotlinx:kotlinx-coroutines-core")
-    api("org.slf4j:slf4j-api")
+    api(libs.coroutines.core)
+    api(libs.slf4j.api)
 }

--- a/docker-kotlin-redis/build.gradle.kts
+++ b/docker-kotlin-redis/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-    kotlin("jvm")
+    alias(libs.plugins.kotlin.jvm)
     `java-library`
 }
 

--- a/docker-kotlin-templates/build.gradle.kts
+++ b/docker-kotlin-templates/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-    kotlin("jvm")
+    alias(libs.plugins.kotlin.jvm)
     `java-library`
 }
 

--- a/docker-kotlin-testing/build.gradle.kts
+++ b/docker-kotlin-testing/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-    kotlin("jvm")
+    alias(libs.plugins.kotlin.jvm)
     `java-library`
 }
 
@@ -7,10 +7,7 @@ description = "Testing utilities for docker-kotlin with JUnit 5 integration"
 
 dependencies {
     api(project(":docker-kotlin-templates"))
+    api(libs.junit.jupiter.api)
 
-    // JUnit 5 for extensions
-    api("org.junit.jupiter:junit-jupiter-api:5.11.4")
-
-    // Optional: JUnit 5 engine for running tests
-    testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:5.11.4")
+    testRuntimeOnly(libs.junit.jupiter.engine)
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,0 +1,38 @@
+[versions]
+kotlin = "2.1.0"
+coroutines = "1.9.0"
+slf4j = "2.0.16"
+logback = "1.5.12"
+junit-jupiter = "5.11.4"
+junit-platform = "1.11.4"
+snakeyaml = "2.3"
+
+[libraries]
+# Kotlin
+kotlin-stdlib = { module = "org.jetbrains.kotlin:kotlin-stdlib", version.ref = "kotlin" }
+kotlin-test = { module = "org.jetbrains.kotlin:kotlin-test", version.ref = "kotlin" }
+
+# Coroutines
+coroutines-bom = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-bom", version.ref = "coroutines" }
+coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core" }
+coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test" }
+
+# Logging
+slf4j-api = { module = "org.slf4j:slf4j-api", version.ref = "slf4j" }
+logback-classic = { module = "ch.qos.logback:logback-classic", version.ref = "logback" }
+
+# Testing
+junit-bom = { module = "org.junit:junit-bom", version.ref = "junit-jupiter" }
+junit-jupiter = { module = "org.junit.jupiter:junit-jupiter", version.ref = "junit-jupiter" }
+junit-jupiter-api = { module = "org.junit.jupiter:junit-jupiter-api", version.ref = "junit-jupiter" }
+junit-jupiter-engine = { module = "org.junit.jupiter:junit-jupiter-engine", version.ref = "junit-jupiter" }
+junit-platform-launcher = { module = "org.junit.platform:junit-platform-launcher", version.ref = "junit-platform" }
+
+# YAML
+snakeyaml = { module = "org.yaml:snakeyaml", version.ref = "snakeyaml" }
+
+[bundles]
+testing = ["kotlin-test", "coroutines-test", "junit-jupiter"]
+
+[plugins]
+kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }


### PR DESCRIPTION
Centralizes dependency management using Gradle's version catalog feature.

## Changes
- Add `gradle/libs.versions.toml` with all dependency versions
- Update root `build.gradle.kts` to use catalog references
- Update all subproject build files to use catalog
- Use bundles for common test dependencies

## Benefits
- Single source of truth for dependency versions
- Easier dependency updates (Dependabot can update the TOML file)
- Type-safe accessors in build scripts (`libs.coroutines.core` instead of strings)
- Better visibility of all dependencies in one place