### PR TITLE
test: add runtime detection and integration tests for Docker alternatives

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,7 +202,24 @@ ComposeSpec compose = ComposeBuilder.create()
 
 - JDK 17+
 - Docker CLI installed and available in PATH
-- Docker daemon running (Docker Desktop, Colima, Podman, etc.)
+- Docker daemon running
+
+## Runtime Compatibility
+
+The library automatically detects and works with Docker-compatible runtimes:
+
+| Runtime | Status | Notes |
+|---------|--------|-------|
+| Docker Engine | Tested | Full support |
+| Docker Desktop | Tested | Full support (macOS, Windows, Linux) |
+| Colima | Supported | Uses `docker` CLI |
+| OrbStack | Supported | Uses `docker` CLI |
+| Rancher Desktop | Supported | Uses `docker` CLI (dockerd mode) |
+| Podman | Supported | Alias `docker=podman` or use native detection |
+
+The library detects the runtime via `docker context show` and configures socket paths automatically. For Podman, you can either:
+- Use the alias: `alias docker=podman` (recommended by Podman docs)
+- Let the library detect Podman natively and use the `podman` command
 
 ## Documentation
 

--- a/docker-kotlin-core/src/test/kotlin/io/github/joshrotenberg/dockerkotlin/core/platform/DockerAlternativesIntegrationTest.kt
+++ b/docker-kotlin-core/src/test/kotlin/io/github/joshrotenberg/dockerkotlin/core/platform/DockerAlternativesIntegrationTest.kt
@@ -1,0 +1,159 @@
+package io.github.joshrotenberg.dockerkotlin.core.platform
+
+import io.github.joshrotenberg.dockerkotlin.core.CommandExecutor
+import io.github.joshrotenberg.dockerkotlin.core.command.PullCommand
+import io.github.joshrotenberg.dockerkotlin.core.command.RmCommand
+import io.github.joshrotenberg.dockerkotlin.core.command.RunCommand
+import io.github.joshrotenberg.dockerkotlin.core.command.network.NetworkCreateCommand
+import io.github.joshrotenberg.dockerkotlin.core.command.network.NetworkRmCommand
+import io.github.joshrotenberg.dockerkotlin.core.command.volume.VolumeCreateCommand
+import io.github.joshrotenberg.dockerkotlin.core.command.volume.VolumeRmCommand
+import kotlinx.coroutines.runBlocking
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.MethodOrderer
+import org.junit.jupiter.api.Order
+import org.junit.jupiter.api.Tag
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.junit.jupiter.api.TestMethodOrder
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * Integration tests that verify compatibility with Docker-compatible runtimes.
+ *
+ * These tests run actual Docker commands against whatever runtime is configured.
+ * They are tagged with "integration" so they can be run separately from unit tests.
+ *
+ * Compatible runtimes (all use `docker` CLI or alias):
+ * - Docker Engine / Docker Desktop
+ * - Colima (macOS) - uses docker CLI
+ * - OrbStack (macOS) - uses docker CLI
+ * - Rancher Desktop - uses docker CLI
+ * - Podman - can be aliased as `docker` per Podman docs
+ *
+ * Run with: ./gradlew :docker-kotlin-core:test --tests "*IntegrationTest"
+ */
+@Tag("integration")
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@TestMethodOrder(MethodOrderer.OrderAnnotation::class)
+class DockerAlternativesIntegrationTest {
+
+    private lateinit var platformInfo: PlatformInfo
+    private lateinit var executor: CommandExecutor
+
+    companion object {
+        private const val TEST_IMAGE = "alpine:latest"
+        private const val TEST_CONTAINER = "docker-kotlin-integration-test"
+        private const val TEST_NETWORK = "docker-kotlin-integration-network"
+        private const val TEST_VOLUME = "docker-kotlin-integration-volume"
+    }
+
+    @BeforeAll
+    fun setup() {
+        platformInfo = PlatformInfo.detect()
+        executor = CommandExecutor(platformInfo)
+
+        println("=".repeat(60))
+        println("Docker Alternatives Integration Test")
+        println("=".repeat(60))
+        println("Runtime: ${platformInfo.runtime}")
+        println("Version: ${platformInfo.version}")
+        println("Platform: ${platformInfo.platform}")
+        println("Socket: ${platformInfo.socketPath}")
+        println("=".repeat(60))
+
+        // Clean up any leftover resources from previous runs
+        cleanup()
+    }
+
+    @AfterAll
+    fun teardown() {
+        cleanup()
+    }
+
+    private fun cleanup() {
+        listOf(
+            listOf("rm", "-f", TEST_CONTAINER),
+            listOf("network", "rm", TEST_NETWORK),
+            listOf("volume", "rm", TEST_VOLUME)
+        ).forEach { cmd ->
+            runCatching { runBlocking { executor.execute(cmd) } }
+        }
+    }
+
+    @Test
+    @Order(1)
+    fun `pull image`() = runBlocking {
+        val command = PullCommand(TEST_IMAGE, executor)
+        command.execute()
+        // If we get here without exception, pull succeeded
+    }
+
+    @Test
+    @Order(2)
+    fun `create and remove network`() = runBlocking {
+        // Create network
+        val networkId = NetworkCreateCommand(TEST_NETWORK, executor).execute()
+        assertTrue(networkId.isNotBlank(), "Network create should return network ID")
+
+        // Remove network
+        NetworkRmCommand(TEST_NETWORK, executor).execute()
+    }
+
+    @Test
+    @Order(3)
+    fun `create and remove volume`() = runBlocking {
+        // Create volume
+        val volumeName = VolumeCreateCommand(executor).name(TEST_VOLUME).execute()
+        assertEquals(TEST_VOLUME, volumeName, "Volume create should return volume name")
+
+        // Remove volume
+        VolumeRmCommand(TEST_VOLUME, executor).execute()
+    }
+
+    @Test
+    @Order(4)
+    fun `run container and capture output`() = runBlocking {
+        val containerId = RunCommand(TEST_IMAGE, executor)
+            .name(TEST_CONTAINER)
+            .rm()
+            .command("echo", "hello from docker-kotlin")
+            .execute()
+
+        assertTrue(containerId.value.isNotBlank(), "Should return container ID or output")
+    }
+
+    @Test
+    @Order(5)
+    fun `run detached container and remove`() = runBlocking {
+        // Run detached
+        val containerId = RunCommand(TEST_IMAGE, executor)
+            .name(TEST_CONTAINER)
+            .detach()
+            .command("sleep", "30")
+            .execute()
+
+        assertTrue(containerId.value.isNotBlank(), "Should return container ID")
+
+        // Remove with force
+        RmCommand(TEST_CONTAINER, executor).force().execute()
+    }
+
+    @Test
+    @Order(6)
+    fun `docker info works`() = runBlocking {
+        val output = executor.execute(listOf("info", "--format", "{{.ServerVersion}}"))
+        assertEquals(0, output.exitCode, "docker info should succeed")
+        assertTrue(output.stdout.isNotBlank(), "Should return server version")
+    }
+
+    @Test
+    @Order(7)
+    fun `docker version works`() = runBlocking {
+        val output = executor.execute(listOf("version", "--format", "{{.Client.Version}}"))
+        assertEquals(0, output.exitCode, "docker version should succeed")
+        assertTrue(output.stdout.isNotBlank(), "Should return client version")
+    }
+}

--- a/docker-kotlin-core/src/test/kotlin/io/github/joshrotenberg/dockerkotlin/core/platform/PlatformInfoTest.kt
+++ b/docker-kotlin-core/src/test/kotlin/io/github/joshrotenberg/dockerkotlin/core/platform/PlatformInfoTest.kt
@@ -1,0 +1,75 @@
+package io.github.joshrotenberg.dockerkotlin.core.platform
+
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+class PlatformInfoTest {
+
+    @Test
+    fun `detect returns valid platform info`() {
+        val info = PlatformInfo.detect()
+
+        assertNotNull(info.runtime)
+        assertNotNull(info.platform)
+        assertNotEquals("unknown", info.version, "Should detect Docker version")
+    }
+
+    @Test
+    fun `detected platform matches OS`() {
+        val info = PlatformInfo.detect()
+        val osName = System.getProperty("os.name").lowercase()
+
+        when {
+            osName.contains("mac") -> assertEquals(Platform.MACOS, info.platform)
+            osName.contains("linux") -> assertEquals(Platform.LINUX, info.platform)
+            osName.contains("win") -> assertEquals(Platform.WINDOWS, info.platform)
+        }
+    }
+
+    @Test
+    fun `socket path is detected on unix systems`() {
+        val info = PlatformInfo.detect()
+
+        if (info.platform != Platform.WINDOWS) {
+            // Socket path should be set on Unix systems
+            // May be null if DOCKER_HOST uses tcp:// or other protocol
+            val dockerHost = System.getenv("DOCKER_HOST")
+            if (dockerHost == null || dockerHost.startsWith("unix://")) {
+                assertNotNull(info.socketPath, "Socket path should be detected on Unix")
+                assertTrue(
+                    info.socketPath.toString().endsWith(".sock"),
+                    "Socket path should end with .sock"
+                )
+            }
+        }
+    }
+
+    @Test
+    fun `version is parseable`() {
+        val info = PlatformInfo.detect()
+
+        // Version should be something like "24.0.7" or "4.25.0"
+        assertTrue(
+            info.version.matches(Regex("^\\d+\\..*")) || info.version == "unknown",
+            "Version '${info.version}' should start with a number"
+        )
+    }
+
+    @Test
+    fun `runtime command is executable`() {
+        val info = PlatformInfo.detect()
+
+        val result = runCatching {
+            ProcessBuilder(info.runtime.command, "info", "--format", "{{.ID}}")
+                .redirectErrorStream(true)
+                .start()
+                .waitFor()
+        }
+
+        assertTrue(result.isSuccess, "Should be able to execute docker info")
+        assertEquals(0, result.getOrNull(), "docker info should succeed")
+    }
+}

--- a/docker-kotlin-core/src/test/kotlin/io/github/joshrotenberg/dockerkotlin/core/platform/RuntimeTest.kt
+++ b/docker-kotlin-core/src/test/kotlin/io/github/joshrotenberg/dockerkotlin/core/platform/RuntimeTest.kt
@@ -1,0 +1,53 @@
+package io.github.joshrotenberg.dockerkotlin.core.platform
+
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable
+import org.junit.jupiter.api.condition.EnabledOnOs
+import org.junit.jupiter.api.condition.OS
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+class RuntimeTest {
+
+    @Test
+    fun `Runtime enum has expected values`() {
+        val runtimes = Runtime.entries
+        assertTrue(runtimes.contains(Runtime.DOCKER))
+        assertTrue(runtimes.contains(Runtime.PODMAN))
+        assertTrue(runtimes.contains(Runtime.COLIMA))
+        assertTrue(runtimes.contains(Runtime.ORBSTACK))
+        assertTrue(runtimes.contains(Runtime.RANCHER_DESKTOP))
+        assertTrue(runtimes.contains(Runtime.DOCKER_DESKTOP))
+    }
+
+    @Test
+    fun `Runtime commands are correct`() {
+        assertEquals("docker", Runtime.DOCKER.command)
+        assertEquals("podman", Runtime.PODMAN.command)
+        assertEquals("docker", Runtime.COLIMA.command)
+        assertEquals("docker", Runtime.ORBSTACK.command)
+        assertEquals("docker", Runtime.RANCHER_DESKTOP.command)
+        assertEquals("docker", Runtime.DOCKER_DESKTOP.command)
+    }
+
+    @Test
+    fun `detect returns a valid runtime`() {
+        val runtime = Runtime.detect()
+        assertNotNull(runtime)
+        assertTrue(runtime in Runtime.entries)
+    }
+
+    @Test
+    fun `detected runtime command exists`() {
+        val runtime = Runtime.detect()
+        val result = runCatching {
+            ProcessBuilder(runtime.command, "version")
+                .redirectErrorStream(true)
+                .start()
+                .waitFor()
+        }
+        assertTrue(result.isSuccess, "Runtime command '${runtime.command}' should be executable")
+        assertEquals(0, result.getOrNull(), "Runtime command should exit with 0")
+    }
+}


### PR DESCRIPTION
## Summary
Adds tests to verify compatibility with Docker-compatible runtimes and updates documentation.

## Changes
- Add `RuntimeTest` - verifies runtime enum values and detection
- Add `PlatformInfoTest` - verifies platform detection (OS, socket path, version)
- Add `DockerAlternativesIntegrationTest` - integration tests for:
  - Image pull
  - Network create/remove
  - Volume create/remove
  - Container run with output capture
  - Detached container lifecycle
  - Docker info/version commands
- Update README with runtime compatibility table

## Runtime Compatibility

| Runtime | Status | Notes |
|---------|--------|-------|
| Docker Engine | Tested | Full support |
| Docker Desktop | Tested | Full support |
| Colima | Supported | Uses docker CLI |
| OrbStack | Supported | Uses docker CLI |
| Rancher Desktop | Supported | Uses docker CLI |
| Podman | Supported | Via alias or native detection |

## Testing
```bash
./gradlew :docker-kotlin-core:test --tests "*IntegrationTest"
```

Closes #15