### PR TITLE
feat: add Docker Swarm commands and fix ExecCommand exit code handling

### DIFF
--- a/docker-kotlin-core/src/main/kotlin/io/github/joshrotenberg/dockerkotlin/core/command/ExecCommand.kt
+++ b/docker-kotlin-core/src/main/kotlin/io/github/joshrotenberg/dockerkotlin/core/command/ExecCommand.kt
@@ -106,7 +106,10 @@ class ExecCommand(
     }
 
     override suspend fun execute(): ExecOutput {
-        val output = executeRaw()
+        // Don't use executeRaw() as it throws on non-zero exit codes.
+        // For exec commands, non-zero exits are valid results (e.g., test commands).
+        val args = buildArgs() + rawArgs
+        val output = executor.execute(args, commandTimeout)
         return ExecOutput(
             stdout = output.stdout,
             stderr = output.stderr,
@@ -115,7 +118,10 @@ class ExecCommand(
     }
 
     override fun executeBlocking(): ExecOutput {
-        val output = executeRawBlocking()
+        // Don't use executeRawBlocking() as it throws on non-zero exit codes.
+        // For exec commands, non-zero exits are valid results (e.g., test commands).
+        val args = buildArgs() + rawArgs
+        val output = executor.executeBlocking(args, commandTimeout)
         return ExecOutput(
             stdout = output.stdout,
             stderr = output.stderr,

--- a/docker-kotlin-core/src/main/kotlin/io/github/joshrotenberg/dockerkotlin/core/command/swarm/SwarmCaCommand.kt
+++ b/docker-kotlin-core/src/main/kotlin/io/github/joshrotenberg/dockerkotlin/core/command/swarm/SwarmCaCommand.kt
@@ -1,0 +1,81 @@
+package io.github.joshrotenberg.dockerkotlin.core.command.swarm
+
+import io.github.joshrotenberg.dockerkotlin.core.CommandExecutor
+import io.github.joshrotenberg.dockerkotlin.core.command.AbstractDockerCommand
+
+/**
+ * Command to display and rotate the root CA.
+ *
+ * Equivalent to `docker swarm ca`.
+ *
+ * Example usage:
+ * ```kotlin
+ * // Display the current CA certificate
+ * val caCert = SwarmCaCommand()
+ *     .execute()
+ *
+ * // Rotate the CA certificate
+ * SwarmCaCommand()
+ *     .rotate()
+ *     .certExpiry("8760h")
+ *     .execute()
+ * ```
+ */
+class SwarmCaCommand(
+    executor: CommandExecutor = CommandExecutor()
+) : AbstractDockerCommand<String>(executor) {
+
+    private var caCert: String? = null
+    private var caKey: String? = null
+    private var certExpiry: String? = null
+    private var detach = false
+    private var externalCa: String? = null
+    private var quiet = false
+    private var rotate = false
+
+    /** Path to the PEM-formatted root CA certificate to use. */
+    fun caCert(path: String) = apply { caCert = path }
+
+    /** Path to the PEM-formatted root CA key to use. */
+    fun caKey(path: String) = apply { caKey = path }
+
+    /** Validity period for node certificates (e.g., "2160h0m0s"). */
+    fun certExpiry(expiry: String) = apply { certExpiry = expiry }
+
+    /** Exit immediately instead of waiting for CA rotation to finish. */
+    fun detach() = apply { detach = true }
+
+    /** Specifications of one or more certificate signing endpoints. */
+    fun externalCa(ca: String) = apply { externalCa = ca }
+
+    /** Suppress progress output. */
+    fun quiet() = apply { quiet = true }
+
+    /** Rotate the swarm CA. */
+    fun rotate() = apply { rotate = true }
+
+    override fun buildArgs(): List<String> = buildList {
+        add("swarm")
+        add("ca")
+        caCert?.let { add("--ca-cert"); add(it) }
+        caKey?.let { add("--ca-key"); add(it) }
+        certExpiry?.let { add("--cert-expiry"); add(it) }
+        if (detach) add("--detach")
+        externalCa?.let { add("--external-ca"); add(it) }
+        if (quiet) add("--quiet")
+        if (rotate) add("--rotate")
+    }
+
+    override suspend fun execute(): String {
+        return executeRaw().stdout
+    }
+
+    override fun executeBlocking(): String {
+        return executeRawBlocking().stdout
+    }
+
+    companion object {
+        @JvmStatic
+        fun builder(): SwarmCaCommand = SwarmCaCommand()
+    }
+}

--- a/docker-kotlin-core/src/main/kotlin/io/github/joshrotenberg/dockerkotlin/core/command/swarm/SwarmInitCommand.kt
+++ b/docker-kotlin-core/src/main/kotlin/io/github/joshrotenberg/dockerkotlin/core/command/swarm/SwarmInitCommand.kt
@@ -1,0 +1,119 @@
+package io.github.joshrotenberg.dockerkotlin.core.command.swarm
+
+import io.github.joshrotenberg.dockerkotlin.core.CommandExecutor
+import io.github.joshrotenberg.dockerkotlin.core.command.AbstractDockerCommand
+
+/**
+ * Command to initialize a swarm.
+ *
+ * Equivalent to `docker swarm init`.
+ *
+ * Example usage:
+ * ```kotlin
+ * SwarmInitCommand()
+ *     .advertiseAddr("192.168.1.100")
+ *     .execute()
+ * ```
+ */
+class SwarmInitCommand(
+    executor: CommandExecutor = CommandExecutor()
+) : AbstractDockerCommand<String>(executor) {
+
+    private var advertiseAddr: String? = null
+    private var autolock = false
+    private var availability: NodeAvailability? = null
+    private var certExpiry: String? = null
+    private var dataPathAddr: String? = null
+    private var dataPathPort: Int? = null
+    private var defaultAddrPool: String? = null
+    private var dispatcherHeartbeat: String? = null
+    private var externalCa: String? = null
+    private var forceNewCluster = false
+    private var listenAddr: String? = null
+    private var maxSnapshots: Int? = null
+    private var snapshotInterval: Int? = null
+    private var taskHistoryLimit: Int? = null
+
+    /** Advertised address (format: "<ip|interface>[:port]"). */
+    fun advertiseAddr(addr: String) = apply { advertiseAddr = addr }
+
+    /** Enable manager autolocking (requiring unlock key to start). */
+    fun autolock() = apply { autolock = true }
+
+    /** Availability of the node ("active", "pause", "drain"). */
+    fun availability(availability: NodeAvailability) = apply { this.availability = availability }
+
+    /** Validity period for node certificates (e.g., "2160h0m0s"). */
+    fun certExpiry(expiry: String) = apply { certExpiry = expiry }
+
+    /** Address or interface to use for data path traffic. */
+    fun dataPathAddr(addr: String) = apply { dataPathAddr = addr }
+
+    /** Port number to use for data path traffic (1024-49151). */
+    fun dataPathPort(port: Int) = apply { dataPathPort = port }
+
+    /** Default address pool in CIDR format for global scope networks. */
+    fun defaultAddrPool(pool: String) = apply { defaultAddrPool = pool }
+
+    /** Dispatcher heartbeat period (e.g., "5s"). */
+    fun dispatcherHeartbeat(heartbeat: String) = apply { dispatcherHeartbeat = heartbeat }
+
+    /** Specifications of one or more certificate signing endpoints. */
+    fun externalCa(ca: String) = apply { externalCa = ca }
+
+    /** Force create a new cluster from current state. */
+    fun forceNewCluster() = apply { forceNewCluster = true }
+
+    /** Listen address (format: "<ip|interface>[:port]"). */
+    fun listenAddr(addr: String) = apply { listenAddr = addr }
+
+    /** Number of additional Raft snapshots to retain. */
+    fun maxSnapshots(count: Int) = apply { maxSnapshots = count }
+
+    /** Number of log entries between Raft snapshots. */
+    fun snapshotInterval(interval: Int) = apply { snapshotInterval = interval }
+
+    /** Task history retention limit. */
+    fun taskHistoryLimit(limit: Int) = apply { taskHistoryLimit = limit }
+
+    override fun buildArgs(): List<String> = buildList {
+        add("swarm")
+        add("init")
+        advertiseAddr?.let { add("--advertise-addr"); add(it) }
+        if (autolock) add("--autolock")
+        availability?.let { add("--availability"); add(it.value) }
+        certExpiry?.let { add("--cert-expiry"); add(it) }
+        dataPathAddr?.let { add("--data-path-addr"); add(it) }
+        dataPathPort?.let { add("--data-path-port"); add(it.toString()) }
+        defaultAddrPool?.let { add("--default-addr-pool"); add(it) }
+        dispatcherHeartbeat?.let { add("--dispatcher-heartbeat"); add(it) }
+        externalCa?.let { add("--external-ca"); add(it) }
+        if (forceNewCluster) add("--force-new-cluster")
+        listenAddr?.let { add("--listen-addr"); add(it) }
+        maxSnapshots?.let { add("--max-snapshots"); add(it.toString()) }
+        snapshotInterval?.let { add("--snapshot-interval"); add(it.toString()) }
+        taskHistoryLimit?.let { add("--task-history-limit"); add(it.toString()) }
+    }
+
+    override suspend fun execute(): String {
+        return executeRaw().stdout
+    }
+
+    override fun executeBlocking(): String {
+        return executeRawBlocking().stdout
+    }
+
+    companion object {
+        @JvmStatic
+        fun builder(): SwarmInitCommand = SwarmInitCommand()
+    }
+}
+
+/**
+ * Node availability status.
+ */
+enum class NodeAvailability(val value: String) {
+    ACTIVE("active"),
+    PAUSE("pause"),
+    DRAIN("drain")
+}

--- a/docker-kotlin-core/src/main/kotlin/io/github/joshrotenberg/dockerkotlin/core/command/swarm/SwarmJoinCommand.kt
+++ b/docker-kotlin-core/src/main/kotlin/io/github/joshrotenberg/dockerkotlin/core/command/swarm/SwarmJoinCommand.kt
@@ -1,0 +1,67 @@
+package io.github.joshrotenberg.dockerkotlin.core.command.swarm
+
+import io.github.joshrotenberg.dockerkotlin.core.CommandExecutor
+import io.github.joshrotenberg.dockerkotlin.core.command.AbstractDockerCommand
+
+/**
+ * Command to join a swarm as a node and/or manager.
+ *
+ * Equivalent to `docker swarm join`.
+ *
+ * Example usage:
+ * ```kotlin
+ * SwarmJoinCommand("192.168.1.100:2377")
+ *     .token("SWMTKN-1-xxx")
+ *     .execute()
+ * ```
+ */
+class SwarmJoinCommand(
+    private val remoteAddr: String,
+    executor: CommandExecutor = CommandExecutor()
+) : AbstractDockerCommand<Unit>(executor) {
+
+    private var advertiseAddr: String? = null
+    private var availability: NodeAvailability? = null
+    private var dataPathAddr: String? = null
+    private var listenAddr: String? = null
+    private var token: String? = null
+
+    /** Advertised address (format: "<ip|interface>[:port]"). */
+    fun advertiseAddr(addr: String) = apply { advertiseAddr = addr }
+
+    /** Availability of the node ("active", "pause", "drain"). */
+    fun availability(availability: NodeAvailability) = apply { this.availability = availability }
+
+    /** Address or interface to use for data path traffic. */
+    fun dataPathAddr(addr: String) = apply { dataPathAddr = addr }
+
+    /** Listen address (format: "<ip|interface>[:port]"). */
+    fun listenAddr(addr: String) = apply { listenAddr = addr }
+
+    /** Token for entry into the swarm. */
+    fun token(token: String) = apply { this.token = token }
+
+    override fun buildArgs(): List<String> = buildList {
+        add("swarm")
+        add("join")
+        advertiseAddr?.let { add("--advertise-addr"); add(it) }
+        availability?.let { add("--availability"); add(it.value) }
+        dataPathAddr?.let { add("--data-path-addr"); add(it) }
+        listenAddr?.let { add("--listen-addr"); add(it) }
+        token?.let { add("--token"); add(it) }
+        add(remoteAddr)
+    }
+
+    override suspend fun execute() {
+        executeRaw()
+    }
+
+    override fun executeBlocking() {
+        executeRawBlocking()
+    }
+
+    companion object {
+        @JvmStatic
+        fun builder(remoteAddr: String): SwarmJoinCommand = SwarmJoinCommand(remoteAddr)
+    }
+}

--- a/docker-kotlin-core/src/main/kotlin/io/github/joshrotenberg/dockerkotlin/core/command/swarm/SwarmJoinTokenCommand.kt
+++ b/docker-kotlin-core/src/main/kotlin/io/github/joshrotenberg/dockerkotlin/core/command/swarm/SwarmJoinTokenCommand.kt
@@ -1,0 +1,72 @@
+package io.github.joshrotenberg.dockerkotlin.core.command.swarm
+
+import io.github.joshrotenberg.dockerkotlin.core.CommandExecutor
+import io.github.joshrotenberg.dockerkotlin.core.command.AbstractDockerCommand
+
+/**
+ * Token type for join-token command.
+ */
+enum class TokenType(val value: String) {
+    WORKER("worker"),
+    MANAGER("manager")
+}
+
+/**
+ * Command to manage join tokens.
+ *
+ * Equivalent to `docker swarm join-token`.
+ *
+ * Example usage:
+ * ```kotlin
+ * // Get worker join token
+ * val token = SwarmJoinTokenCommand(TokenType.WORKER)
+ *     .quiet()
+ *     .execute()
+ *
+ * // Rotate manager token
+ * SwarmJoinTokenCommand(TokenType.MANAGER)
+ *     .rotate()
+ *     .execute()
+ * ```
+ */
+class SwarmJoinTokenCommand(
+    private val tokenType: TokenType,
+    executor: CommandExecutor = CommandExecutor()
+) : AbstractDockerCommand<String>(executor) {
+
+    private var quiet = false
+    private var rotate = false
+
+    /** Only display token. */
+    fun quiet() = apply { quiet = true }
+
+    /** Rotate join token. */
+    fun rotate() = apply { rotate = true }
+
+    override fun buildArgs(): List<String> = buildList {
+        add("swarm")
+        add("join-token")
+        if (quiet) add("--quiet")
+        if (rotate) add("--rotate")
+        add(tokenType.value)
+    }
+
+    override suspend fun execute(): String {
+        return executeRaw().stdout.trim()
+    }
+
+    override fun executeBlocking(): String {
+        return executeRawBlocking().stdout.trim()
+    }
+
+    companion object {
+        @JvmStatic
+        fun builder(tokenType: TokenType): SwarmJoinTokenCommand = SwarmJoinTokenCommand(tokenType)
+
+        @JvmStatic
+        fun worker(): SwarmJoinTokenCommand = SwarmJoinTokenCommand(TokenType.WORKER)
+
+        @JvmStatic
+        fun manager(): SwarmJoinTokenCommand = SwarmJoinTokenCommand(TokenType.MANAGER)
+    }
+}

--- a/docker-kotlin-core/src/main/kotlin/io/github/joshrotenberg/dockerkotlin/core/command/swarm/SwarmLeaveCommand.kt
+++ b/docker-kotlin-core/src/main/kotlin/io/github/joshrotenberg/dockerkotlin/core/command/swarm/SwarmLeaveCommand.kt
@@ -1,0 +1,45 @@
+package io.github.joshrotenberg.dockerkotlin.core.command.swarm
+
+import io.github.joshrotenberg.dockerkotlin.core.CommandExecutor
+import io.github.joshrotenberg.dockerkotlin.core.command.AbstractDockerCommand
+
+/**
+ * Command to leave the swarm.
+ *
+ * Equivalent to `docker swarm leave`.
+ *
+ * Example usage:
+ * ```kotlin
+ * SwarmLeaveCommand()
+ *     .force()
+ *     .execute()
+ * ```
+ */
+class SwarmLeaveCommand(
+    executor: CommandExecutor = CommandExecutor()
+) : AbstractDockerCommand<Unit>(executor) {
+
+    private var force = false
+
+    /** Force this node to leave the swarm, ignoring warnings. */
+    fun force() = apply { force = true }
+
+    override fun buildArgs(): List<String> = buildList {
+        add("swarm")
+        add("leave")
+        if (force) add("--force")
+    }
+
+    override suspend fun execute() {
+        executeRaw()
+    }
+
+    override fun executeBlocking() {
+        executeRawBlocking()
+    }
+
+    companion object {
+        @JvmStatic
+        fun builder(): SwarmLeaveCommand = SwarmLeaveCommand()
+    }
+}

--- a/docker-kotlin-core/src/main/kotlin/io/github/joshrotenberg/dockerkotlin/core/command/swarm/SwarmUnlockCommand.kt
+++ b/docker-kotlin-core/src/main/kotlin/io/github/joshrotenberg/dockerkotlin/core/command/swarm/SwarmUnlockCommand.kt
@@ -1,0 +1,38 @@
+package io.github.joshrotenberg.dockerkotlin.core.command.swarm
+
+import io.github.joshrotenberg.dockerkotlin.core.CommandExecutor
+import io.github.joshrotenberg.dockerkotlin.core.command.AbstractDockerCommand
+
+/**
+ * Command to unlock a locked swarm manager.
+ *
+ * Equivalent to `docker swarm unlock`.
+ *
+ * Note: This command reads the unlock key from stdin when run interactively.
+ * For programmatic use, you may need to pipe the key or use other mechanisms.
+ *
+ * Example usage:
+ * ```kotlin
+ * SwarmUnlockCommand()
+ *     .execute()
+ * ```
+ */
+class SwarmUnlockCommand(
+    executor: CommandExecutor = CommandExecutor()
+) : AbstractDockerCommand<Unit>(executor) {
+
+    override fun buildArgs(): List<String> = listOf("swarm", "unlock")
+
+    override suspend fun execute() {
+        executeRaw()
+    }
+
+    override fun executeBlocking() {
+        executeRawBlocking()
+    }
+
+    companion object {
+        @JvmStatic
+        fun builder(): SwarmUnlockCommand = SwarmUnlockCommand()
+    }
+}

--- a/docker-kotlin-core/src/main/kotlin/io/github/joshrotenberg/dockerkotlin/core/command/swarm/SwarmUnlockKeyCommand.kt
+++ b/docker-kotlin-core/src/main/kotlin/io/github/joshrotenberg/dockerkotlin/core/command/swarm/SwarmUnlockKeyCommand.kt
@@ -1,0 +1,56 @@
+package io.github.joshrotenberg.dockerkotlin.core.command.swarm
+
+import io.github.joshrotenberg.dockerkotlin.core.CommandExecutor
+import io.github.joshrotenberg.dockerkotlin.core.command.AbstractDockerCommand
+
+/**
+ * Command to manage the unlock key.
+ *
+ * Equivalent to `docker swarm unlock-key`.
+ *
+ * Example usage:
+ * ```kotlin
+ * // Get current unlock key
+ * val key = SwarmUnlockKeyCommand()
+ *     .quiet()
+ *     .execute()
+ *
+ * // Rotate the unlock key
+ * SwarmUnlockKeyCommand()
+ *     .rotate()
+ *     .execute()
+ * ```
+ */
+class SwarmUnlockKeyCommand(
+    executor: CommandExecutor = CommandExecutor()
+) : AbstractDockerCommand<String>(executor) {
+
+    private var quiet = false
+    private var rotate = false
+
+    /** Only display the unlock key. */
+    fun quiet() = apply { quiet = true }
+
+    /** Rotate unlock key. */
+    fun rotate() = apply { rotate = true }
+
+    override fun buildArgs(): List<String> = buildList {
+        add("swarm")
+        add("unlock-key")
+        if (quiet) add("--quiet")
+        if (rotate) add("--rotate")
+    }
+
+    override suspend fun execute(): String {
+        return executeRaw().stdout.trim()
+    }
+
+    override fun executeBlocking(): String {
+        return executeRawBlocking().stdout.trim()
+    }
+
+    companion object {
+        @JvmStatic
+        fun builder(): SwarmUnlockKeyCommand = SwarmUnlockKeyCommand()
+    }
+}

--- a/docker-kotlin-core/src/main/kotlin/io/github/joshrotenberg/dockerkotlin/core/command/swarm/SwarmUpdateCommand.kt
+++ b/docker-kotlin-core/src/main/kotlin/io/github/joshrotenberg/dockerkotlin/core/command/swarm/SwarmUpdateCommand.kt
@@ -1,0 +1,76 @@
+package io.github.joshrotenberg.dockerkotlin.core.command.swarm
+
+import io.github.joshrotenberg.dockerkotlin.core.CommandExecutor
+import io.github.joshrotenberg.dockerkotlin.core.command.AbstractDockerCommand
+
+/**
+ * Command to update the swarm.
+ *
+ * Equivalent to `docker swarm update`.
+ *
+ * Example usage:
+ * ```kotlin
+ * SwarmUpdateCommand()
+ *     .taskHistoryLimit(10)
+ *     .autolock()
+ *     .execute()
+ * ```
+ */
+class SwarmUpdateCommand(
+    executor: CommandExecutor = CommandExecutor()
+) : AbstractDockerCommand<Unit>(executor) {
+
+    private var autolock: Boolean? = null
+    private var certExpiry: String? = null
+    private var dispatcherHeartbeat: String? = null
+    private var externalCa: String? = null
+    private var maxSnapshots: Int? = null
+    private var snapshotInterval: Int? = null
+    private var taskHistoryLimit: Int? = null
+
+    /** Enable or disable manager autolocking. */
+    fun autolock(enabled: Boolean = true) = apply { autolock = enabled }
+
+    /** Validity period for node certificates (e.g., "2160h0m0s"). */
+    fun certExpiry(expiry: String) = apply { certExpiry = expiry }
+
+    /** Dispatcher heartbeat period (e.g., "5s"). */
+    fun dispatcherHeartbeat(heartbeat: String) = apply { dispatcherHeartbeat = heartbeat }
+
+    /** Specifications of one or more certificate signing endpoints. */
+    fun externalCa(ca: String) = apply { externalCa = ca }
+
+    /** Number of additional Raft snapshots to retain. */
+    fun maxSnapshots(count: Int) = apply { maxSnapshots = count }
+
+    /** Number of log entries between Raft snapshots. */
+    fun snapshotInterval(interval: Int) = apply { snapshotInterval = interval }
+
+    /** Task history retention limit. */
+    fun taskHistoryLimit(limit: Int) = apply { taskHistoryLimit = limit }
+
+    override fun buildArgs(): List<String> = buildList {
+        add("swarm")
+        add("update")
+        autolock?.let { add("--autolock=$it") }
+        certExpiry?.let { add("--cert-expiry"); add(it) }
+        dispatcherHeartbeat?.let { add("--dispatcher-heartbeat"); add(it) }
+        externalCa?.let { add("--external-ca"); add(it) }
+        maxSnapshots?.let { add("--max-snapshots"); add(it.toString()) }
+        snapshotInterval?.let { add("--snapshot-interval"); add(it.toString()) }
+        taskHistoryLimit?.let { add("--task-history-limit"); add(it.toString()) }
+    }
+
+    override suspend fun execute() {
+        executeRaw()
+    }
+
+    override fun executeBlocking() {
+        executeRawBlocking()
+    }
+
+    companion object {
+        @JvmStatic
+        fun builder(): SwarmUpdateCommand = SwarmUpdateCommand()
+    }
+}

--- a/docker-kotlin-core/src/test/kotlin/io/github/joshrotenberg/dockerkotlin/core/command/swarm/SwarmCommandsTest.kt
+++ b/docker-kotlin-core/src/test/kotlin/io/github/joshrotenberg/dockerkotlin/core/command/swarm/SwarmCommandsTest.kt
@@ -1,0 +1,278 @@
+package io.github.joshrotenberg.dockerkotlin.core.command.swarm
+
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class SwarmCommandsTest {
+
+    // SwarmInitCommand tests
+
+    @Test
+    fun `SwarmInitCommand buildArgs basic`() {
+        val command = SwarmInitCommand()
+        assertEquals(listOf("swarm", "init"), command.buildArgs())
+    }
+
+    @Test
+    fun `SwarmInitCommand buildArgs with advertise addr`() {
+        val command = SwarmInitCommand()
+            .advertiseAddr("192.168.1.100")
+        val args = command.buildArgs()
+        assertTrue(args.contains("--advertise-addr"))
+        assertTrue(args.contains("192.168.1.100"))
+    }
+
+    @Test
+    fun `SwarmInitCommand buildArgs with autolock`() {
+        val command = SwarmInitCommand()
+            .autolock()
+        val args = command.buildArgs()
+        assertTrue(args.contains("--autolock"))
+    }
+
+    @Test
+    fun `SwarmInitCommand buildArgs with availability`() {
+        val command = SwarmInitCommand()
+            .availability(NodeAvailability.DRAIN)
+        val args = command.buildArgs()
+        assertTrue(args.contains("--availability"))
+        assertTrue(args.contains("drain"))
+    }
+
+    @Test
+    fun `SwarmInitCommand buildArgs with all options`() {
+        val command = SwarmInitCommand()
+            .advertiseAddr("192.168.1.100:2377")
+            .autolock()
+            .certExpiry("8760h")
+            .dataPathAddr("eth0")
+            .dataPathPort(4789)
+            .listenAddr("0.0.0.0:2377")
+            .forceNewCluster()
+            .taskHistoryLimit(10)
+        val args = command.buildArgs()
+        assertTrue(args.contains("--advertise-addr"))
+        assertTrue(args.contains("--autolock"))
+        assertTrue(args.contains("--cert-expiry"))
+        assertTrue(args.contains("--data-path-addr"))
+        assertTrue(args.contains("--data-path-port"))
+        assertTrue(args.contains("--listen-addr"))
+        assertTrue(args.contains("--force-new-cluster"))
+        assertTrue(args.contains("--task-history-limit"))
+    }
+
+    // SwarmJoinCommand tests
+
+    @Test
+    fun `SwarmJoinCommand buildArgs basic`() {
+        val command = SwarmJoinCommand("192.168.1.100:2377")
+        val args = command.buildArgs()
+        assertEquals("swarm", args[0])
+        assertEquals("join", args[1])
+        assertTrue(args.contains("192.168.1.100:2377"))
+    }
+
+    @Test
+    fun `SwarmJoinCommand buildArgs with token`() {
+        val command = SwarmJoinCommand("192.168.1.100:2377")
+            .token("SWMTKN-1-xxx")
+        val args = command.buildArgs()
+        assertTrue(args.contains("--token"))
+        assertTrue(args.contains("SWMTKN-1-xxx"))
+    }
+
+    @Test
+    fun `SwarmJoinCommand buildArgs with all options`() {
+        val command = SwarmJoinCommand("192.168.1.100:2377")
+            .token("SWMTKN-1-xxx")
+            .advertiseAddr("192.168.1.101")
+            .availability(NodeAvailability.ACTIVE)
+            .dataPathAddr("eth0")
+            .listenAddr("0.0.0.0:2377")
+        val args = command.buildArgs()
+        assertTrue(args.contains("--token"))
+        assertTrue(args.contains("--advertise-addr"))
+        assertTrue(args.contains("--availability"))
+        assertTrue(args.contains("--data-path-addr"))
+        assertTrue(args.contains("--listen-addr"))
+    }
+
+    // SwarmLeaveCommand tests
+
+    @Test
+    fun `SwarmLeaveCommand buildArgs basic`() {
+        val command = SwarmLeaveCommand()
+        assertEquals(listOf("swarm", "leave"), command.buildArgs())
+    }
+
+    @Test
+    fun `SwarmLeaveCommand buildArgs with force`() {
+        val command = SwarmLeaveCommand()
+            .force()
+        val args = command.buildArgs()
+        assertTrue(args.contains("--force"))
+    }
+
+    // SwarmJoinTokenCommand tests
+
+    @Test
+    fun `SwarmJoinTokenCommand buildArgs worker`() {
+        val command = SwarmJoinTokenCommand(TokenType.WORKER)
+        val args = command.buildArgs()
+        assertEquals("swarm", args[0])
+        assertEquals("join-token", args[1])
+        assertTrue(args.contains("worker"))
+    }
+
+    @Test
+    fun `SwarmJoinTokenCommand buildArgs manager`() {
+        val command = SwarmJoinTokenCommand(TokenType.MANAGER)
+        val args = command.buildArgs()
+        assertTrue(args.contains("manager"))
+    }
+
+    @Test
+    fun `SwarmJoinTokenCommand buildArgs with quiet`() {
+        val command = SwarmJoinTokenCommand(TokenType.WORKER)
+            .quiet()
+        val args = command.buildArgs()
+        assertTrue(args.contains("--quiet"))
+    }
+
+    @Test
+    fun `SwarmJoinTokenCommand buildArgs with rotate`() {
+        val command = SwarmJoinTokenCommand(TokenType.MANAGER)
+            .rotate()
+        val args = command.buildArgs()
+        assertTrue(args.contains("--rotate"))
+    }
+
+    @Test
+    fun `SwarmJoinTokenCommand factory methods`() {
+        val workerCmd = SwarmJoinTokenCommand.worker()
+        assertTrue(workerCmd.buildArgs().contains("worker"))
+
+        val managerCmd = SwarmJoinTokenCommand.manager()
+        assertTrue(managerCmd.buildArgs().contains("manager"))
+    }
+
+    // SwarmUpdateCommand tests
+
+    @Test
+    fun `SwarmUpdateCommand buildArgs basic`() {
+        val command = SwarmUpdateCommand()
+        assertEquals(listOf("swarm", "update"), command.buildArgs())
+    }
+
+    @Test
+    fun `SwarmUpdateCommand buildArgs with autolock`() {
+        val command = SwarmUpdateCommand()
+            .autolock(true)
+        val args = command.buildArgs()
+        assertTrue(args.contains("--autolock=true"))
+    }
+
+    @Test
+    fun `SwarmUpdateCommand buildArgs with task history limit`() {
+        val command = SwarmUpdateCommand()
+            .taskHistoryLimit(10)
+        val args = command.buildArgs()
+        assertTrue(args.contains("--task-history-limit"))
+        assertTrue(args.contains("10"))
+    }
+
+    @Test
+    fun `SwarmUpdateCommand buildArgs with all options`() {
+        val command = SwarmUpdateCommand()
+            .autolock(false)
+            .certExpiry("8760h")
+            .dispatcherHeartbeat("10s")
+            .maxSnapshots(5)
+            .snapshotInterval(10000)
+            .taskHistoryLimit(5)
+        val args = command.buildArgs()
+        assertTrue(args.contains("--autolock=false"))
+        assertTrue(args.contains("--cert-expiry"))
+        assertTrue(args.contains("--dispatcher-heartbeat"))
+        assertTrue(args.contains("--max-snapshots"))
+        assertTrue(args.contains("--snapshot-interval"))
+        assertTrue(args.contains("--task-history-limit"))
+    }
+
+    // SwarmUnlockCommand tests
+
+    @Test
+    fun `SwarmUnlockCommand buildArgs`() {
+        val command = SwarmUnlockCommand()
+        assertEquals(listOf("swarm", "unlock"), command.buildArgs())
+    }
+
+    // SwarmUnlockKeyCommand tests
+
+    @Test
+    fun `SwarmUnlockKeyCommand buildArgs basic`() {
+        val command = SwarmUnlockKeyCommand()
+        assertEquals(listOf("swarm", "unlock-key"), command.buildArgs())
+    }
+
+    @Test
+    fun `SwarmUnlockKeyCommand buildArgs with quiet`() {
+        val command = SwarmUnlockKeyCommand()
+            .quiet()
+        val args = command.buildArgs()
+        assertTrue(args.contains("--quiet"))
+    }
+
+    @Test
+    fun `SwarmUnlockKeyCommand buildArgs with rotate`() {
+        val command = SwarmUnlockKeyCommand()
+            .rotate()
+        val args = command.buildArgs()
+        assertTrue(args.contains("--rotate"))
+    }
+
+    // SwarmCaCommand tests
+
+    @Test
+    fun `SwarmCaCommand buildArgs basic`() {
+        val command = SwarmCaCommand()
+        assertEquals(listOf("swarm", "ca"), command.buildArgs())
+    }
+
+    @Test
+    fun `SwarmCaCommand buildArgs with rotate`() {
+        val command = SwarmCaCommand()
+            .rotate()
+        val args = command.buildArgs()
+        assertTrue(args.contains("--rotate"))
+    }
+
+    @Test
+    fun `SwarmCaCommand buildArgs with quiet`() {
+        val command = SwarmCaCommand()
+            .quiet()
+        val args = command.buildArgs()
+        assertTrue(args.contains("--quiet"))
+    }
+
+    @Test
+    fun `SwarmCaCommand buildArgs with all options`() {
+        val command = SwarmCaCommand()
+            .caCert("/path/to/ca.pem")
+            .caKey("/path/to/ca-key.pem")
+            .certExpiry("8760h")
+            .detach()
+            .rotate()
+            .quiet()
+        val args = command.buildArgs()
+        assertTrue(args.contains("--ca-cert"))
+        assertTrue(args.contains("/path/to/ca.pem"))
+        assertTrue(args.contains("--ca-key"))
+        assertTrue(args.contains("/path/to/ca-key.pem"))
+        assertTrue(args.contains("--cert-expiry"))
+        assertTrue(args.contains("--detach"))
+        assertTrue(args.contains("--rotate"))
+        assertTrue(args.contains("--quiet"))
+    }
+}


### PR DESCRIPTION
## Summary

This PR adds Docker Swarm orchestration commands and fixes the ExecCommand to properly return exit codes.

## Changes

### Docker Swarm Commands (#7)
Added 8 new Swarm commands for cluster orchestration:
- **SwarmInitCommand** - Initialize a swarm with configurable options (advertise address, autolock, availability, cert expiry, etc.)
- **SwarmJoinCommand** - Join an existing swarm as worker or manager
- **SwarmLeaveCommand** - Leave a swarm with optional force flag
- **SwarmJoinTokenCommand** - Manage join tokens (view/rotate for worker or manager)
- **SwarmUpdateCommand** - Update swarm settings (autolock, cert expiry, task history limit, etc.)
- **SwarmUnlockCommand** - Unlock a locked swarm manager
- **SwarmUnlockKeyCommand** - Manage the unlock key (view/rotate)
- **SwarmCaCommand** - Display and rotate the root CA

### ExecCommand Fix (#25)
Fixed ExecCommand to return exit codes instead of throwing exceptions on non-zero exits. The previous implementation used `executeRaw()` which throws `DockerException.CommandFailed` on non-zero exit codes. For exec commands, non-zero exits are valid results (e.g., `test -f /file` returns 1 if file doesn't exist).

## Testing
- Added 27 tests for Swarm commands covering all options and argument building
- All existing tests continue to pass

Closes #7
Closes #25