### PR TITLE
feat: add typed responses, complete Docker facade, and fix timeout handling

### DIFF
--- a/docker-kotlin-core/build.gradle.kts
+++ b/docker-kotlin-core/build.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
     alias(libs.plugins.kotlin.jvm)
+    alias(libs.plugins.kotlin.serialization)
     `java-library`
 }
 
@@ -7,5 +8,6 @@ description = "Core Docker CLI wrapper for Kotlin/JVM"
 
 dependencies {
     api(libs.coroutines.core)
+    api(libs.serialization.json)
     api(libs.slf4j.api)
 }

--- a/docker-kotlin-core/src/main/kotlin/io/github/joshrotenberg/dockerkotlin/core/Docker.kt
+++ b/docker-kotlin-core/src/main/kotlin/io/github/joshrotenberg/dockerkotlin/core/Docker.kt
@@ -1,12 +1,35 @@
 package io.github.joshrotenberg.dockerkotlin.core
 
-import io.github.joshrotenberg.dockerkotlin.core.command.PullCommand
-import io.github.joshrotenberg.dockerkotlin.core.command.RmCommand
-import io.github.joshrotenberg.dockerkotlin.core.command.RunCommand
-import io.github.joshrotenberg.dockerkotlin.core.command.StopCommand
-import io.github.joshrotenberg.dockerkotlin.core.command.VersionCommand
-import io.github.joshrotenberg.dockerkotlin.core.command.VersionInfo
+import io.github.joshrotenberg.dockerkotlin.core.command.BuildCommand
 import io.github.joshrotenberg.dockerkotlin.core.command.ContainerId
+import io.github.joshrotenberg.dockerkotlin.core.command.ExecCommand
+import io.github.joshrotenberg.dockerkotlin.core.command.ExecOutput
+import io.github.joshrotenberg.dockerkotlin.core.command.ImagesCommand
+import io.github.joshrotenberg.dockerkotlin.core.command.InfoCommand
+import io.github.joshrotenberg.dockerkotlin.core.command.InspectCommand
+import io.github.joshrotenberg.dockerkotlin.core.command.LogsCommand
+import io.github.joshrotenberg.dockerkotlin.core.command.PsCommand
+import io.github.joshrotenberg.dockerkotlin.core.command.PullCommand
+import io.github.joshrotenberg.dockerkotlin.core.command.PushCommand
+import io.github.joshrotenberg.dockerkotlin.core.command.RmCommand
+import io.github.joshrotenberg.dockerkotlin.core.command.RmiCommand
+import io.github.joshrotenberg.dockerkotlin.core.command.RunCommand
+import io.github.joshrotenberg.dockerkotlin.core.command.StartCommand
+import io.github.joshrotenberg.dockerkotlin.core.command.StopCommand
+import io.github.joshrotenberg.dockerkotlin.core.command.TagCommand
+import io.github.joshrotenberg.dockerkotlin.core.command.VersionCommand
+import io.github.joshrotenberg.dockerkotlin.core.command.network.NetworkCreateCommand
+import io.github.joshrotenberg.dockerkotlin.core.command.network.NetworkLsCommand
+import io.github.joshrotenberg.dockerkotlin.core.command.network.NetworkRmCommand
+import io.github.joshrotenberg.dockerkotlin.core.command.volume.VolumeCreateCommand
+import io.github.joshrotenberg.dockerkotlin.core.command.volume.VolumeLsCommand
+import io.github.joshrotenberg.dockerkotlin.core.command.volume.VolumeRmCommand
+import io.github.joshrotenberg.dockerkotlin.core.model.ContainerSummary
+import io.github.joshrotenberg.dockerkotlin.core.model.DockerInfo
+import io.github.joshrotenberg.dockerkotlin.core.model.DockerVersion
+import io.github.joshrotenberg.dockerkotlin.core.model.ImageSummary
+import io.github.joshrotenberg.dockerkotlin.core.model.NetworkSummary
+import io.github.joshrotenberg.dockerkotlin.core.model.VolumeSummary
 import io.github.joshrotenberg.dockerkotlin.core.platform.PlatformInfo
 
 /**
@@ -53,15 +76,29 @@ class Docker(
         )
     }
 
+    // ========== System Commands ==========
+
     /**
      * Get Docker version information.
      */
-    suspend fun version(): VersionInfo = VersionCommand(executor).execute()
+    suspend fun version(): DockerVersion = VersionCommand(executor).execute()
 
     /**
      * Get Docker version information (blocking).
      */
-    fun versionBlocking(): VersionInfo = VersionCommand(executor).executeBlocking()
+    fun versionBlocking(): DockerVersion = VersionCommand(executor).executeBlocking()
+
+    /**
+     * Get Docker system information.
+     */
+    suspend fun info(): DockerInfo = InfoCommand(executor).execute()
+
+    /**
+     * Get Docker system information (blocking).
+     */
+    fun infoBlocking(): DockerInfo = InfoCommand(executor).executeBlocking()
+
+    // ========== Container Lifecycle ==========
 
     /**
      * Run a container with the given image.
@@ -79,6 +116,23 @@ class Docker(
      */
     fun runBlocking(image: String, configure: RunCommand.() -> Unit = {}): ContainerId {
         return RunCommand(image, executor).apply(configure).executeBlocking()
+    }
+
+    /**
+     * Start a stopped container.
+     *
+     * @param container Container ID or name
+     * @param configure Configuration block for the start command
+     */
+    suspend fun start(container: String, configure: StartCommand.() -> Unit = {}) {
+        StartCommand(container, executor).apply(configure).execute()
+    }
+
+    /**
+     * Start a stopped container (blocking).
+     */
+    fun startBlocking(container: String, configure: StartCommand.() -> Unit = {}) {
+        StartCommand(container, executor).apply(configure).executeBlocking()
     }
 
     /**
@@ -116,6 +170,88 @@ class Docker(
     }
 
     /**
+     * List containers.
+     *
+     * @param configure Configuration block for the ps command
+     * @return List of containers
+     */
+    suspend fun ps(configure: PsCommand.() -> Unit = {}): List<ContainerSummary> {
+        return PsCommand(executor).apply(configure).execute()
+    }
+
+    /**
+     * List containers (blocking).
+     */
+    fun psBlocking(configure: PsCommand.() -> Unit = {}): List<ContainerSummary> {
+        return PsCommand(executor).apply(configure).executeBlocking()
+    }
+
+    /**
+     * Execute a command in a running container.
+     *
+     * @param container Container ID or name
+     * @param command Command to execute
+     * @param configure Configuration block for the exec command
+     * @return Execution output
+     */
+    suspend fun exec(
+        container: String,
+        vararg command: String,
+        configure: ExecCommand.() -> Unit = {}
+    ): ExecOutput {
+        return ExecCommand(container, command.toList(), executor).apply(configure).execute()
+    }
+
+    /**
+     * Execute a command in a running container (blocking).
+     */
+    fun execBlocking(
+        container: String,
+        vararg command: String,
+        configure: ExecCommand.() -> Unit = {}
+    ): ExecOutput {
+        return ExecCommand(container, command.toList(), executor).apply(configure).executeBlocking()
+    }
+
+    /**
+     * Fetch container logs.
+     *
+     * @param container Container ID or name
+     * @param configure Configuration block for the logs command
+     * @return Log output
+     */
+    suspend fun logs(container: String, configure: LogsCommand.() -> Unit = {}): String {
+        return LogsCommand(container, executor).apply(configure).execute()
+    }
+
+    /**
+     * Fetch container logs (blocking).
+     */
+    fun logsBlocking(container: String, configure: LogsCommand.() -> Unit = {}): String {
+        return LogsCommand(container, executor).apply(configure).executeBlocking()
+    }
+
+    /**
+     * Inspect a container or image.
+     *
+     * @param obj Object to inspect (container ID, image, etc.)
+     * @param configure Configuration block for the inspect command
+     * @return JSON inspection output
+     */
+    suspend fun inspect(obj: String, configure: InspectCommand.() -> Unit = {}): String {
+        return InspectCommand(obj, executor).apply(configure).execute()
+    }
+
+    /**
+     * Inspect a container or image (blocking).
+     */
+    fun inspectBlocking(obj: String, configure: InspectCommand.() -> Unit = {}): String {
+        return InspectCommand(obj, executor).apply(configure).executeBlocking()
+    }
+
+    // ========== Image Commands ==========
+
+    /**
      * Pull an image from a registry.
      *
      * @param image The image to pull
@@ -130,6 +266,209 @@ class Docker(
      */
     fun pullBlocking(image: String, configure: PullCommand.() -> Unit = {}) {
         PullCommand(image, executor).apply(configure).executeBlocking()
+    }
+
+    /**
+     * Push an image to a registry.
+     *
+     * @param image The image to push
+     * @param configure Configuration block for the push command
+     */
+    suspend fun push(image: String, configure: PushCommand.() -> Unit = {}) {
+        PushCommand(image, executor).apply(configure).execute()
+    }
+
+    /**
+     * Push an image to a registry (blocking).
+     */
+    fun pushBlocking(image: String, configure: PushCommand.() -> Unit = {}) {
+        PushCommand(image, executor).apply(configure).executeBlocking()
+    }
+
+    /**
+     * Build an image from a Dockerfile.
+     *
+     * @param context Build context path
+     * @param configure Configuration block for the build command
+     * @return Build output
+     */
+    suspend fun build(context: String, configure: BuildCommand.() -> Unit = {}): String {
+        return BuildCommand(context, executor).apply(configure).execute()
+    }
+
+    /**
+     * Build an image from a Dockerfile (blocking).
+     */
+    fun buildBlocking(context: String, configure: BuildCommand.() -> Unit = {}): String {
+        return BuildCommand(context, executor).apply(configure).executeBlocking()
+    }
+
+    /**
+     * List images.
+     *
+     * @param configure Configuration block for the images command
+     * @return List of images
+     */
+    suspend fun images(configure: ImagesCommand.() -> Unit = {}): List<ImageSummary> {
+        return ImagesCommand(executor = executor).apply(configure).execute()
+    }
+
+    /**
+     * List images (blocking).
+     */
+    fun imagesBlocking(configure: ImagesCommand.() -> Unit = {}): List<ImageSummary> {
+        return ImagesCommand(executor = executor).apply(configure).executeBlocking()
+    }
+
+    /**
+     * Remove an image.
+     *
+     * @param image Image ID or name
+     * @param configure Configuration block for the rmi command
+     */
+    suspend fun rmi(image: String, configure: RmiCommand.() -> Unit = {}) {
+        RmiCommand(image, executor).apply(configure).execute()
+    }
+
+    /**
+     * Remove an image (blocking).
+     */
+    fun rmiBlocking(image: String, configure: RmiCommand.() -> Unit = {}) {
+        RmiCommand(image, executor).apply(configure).executeBlocking()
+    }
+
+    /**
+     * Tag an image.
+     *
+     * @param source Source image
+     * @param target Target image tag
+     */
+    suspend fun tag(source: String, target: String) {
+        TagCommand(source, target, executor).execute()
+    }
+
+    /**
+     * Tag an image (blocking).
+     */
+    fun tagBlocking(source: String, target: String) {
+        TagCommand(source, target, executor).executeBlocking()
+    }
+
+    // ========== Network Commands ==========
+
+    /** Network management commands. */
+    val network: NetworkCommands = NetworkCommands()
+
+    inner class NetworkCommands {
+        /**
+         * Create a network.
+         *
+         * @param name Network name
+         * @param configure Configuration block
+         * @return Network ID
+         */
+        suspend fun create(name: String, configure: NetworkCreateCommand.() -> Unit = {}): String {
+            return NetworkCreateCommand(name, executor).apply(configure).execute()
+        }
+
+        /**
+         * Create a network (blocking).
+         */
+        fun createBlocking(name: String, configure: NetworkCreateCommand.() -> Unit = {}): String {
+            return NetworkCreateCommand(name, executor).apply(configure).executeBlocking()
+        }
+
+        /**
+         * List networks.
+         *
+         * @param configure Configuration block
+         * @return List of networks
+         */
+        suspend fun ls(configure: NetworkLsCommand.() -> Unit = {}): List<NetworkSummary> {
+            return NetworkLsCommand(executor).apply(configure).execute()
+        }
+
+        /**
+         * List networks (blocking).
+         */
+        fun lsBlocking(configure: NetworkLsCommand.() -> Unit = {}): List<NetworkSummary> {
+            return NetworkLsCommand(executor).apply(configure).executeBlocking()
+        }
+
+        /**
+         * Remove a network.
+         *
+         * @param name Network name or ID
+         * @param configure Configuration block
+         */
+        suspend fun rm(name: String, configure: NetworkRmCommand.() -> Unit = {}) {
+            NetworkRmCommand(name, executor).apply(configure).execute()
+        }
+
+        /**
+         * Remove a network (blocking).
+         */
+        fun rmBlocking(name: String, configure: NetworkRmCommand.() -> Unit = {}) {
+            NetworkRmCommand(name, executor).apply(configure).executeBlocking()
+        }
+    }
+
+    // ========== Volume Commands ==========
+
+    /** Volume management commands. */
+    val volume: VolumeCommands = VolumeCommands()
+
+    inner class VolumeCommands {
+        /**
+         * Create a volume.
+         *
+         * @param configure Configuration block
+         * @return Volume name
+         */
+        suspend fun create(configure: VolumeCreateCommand.() -> Unit = {}): String {
+            return VolumeCreateCommand(executor).apply(configure).execute()
+        }
+
+        /**
+         * Create a volume (blocking).
+         */
+        fun createBlocking(configure: VolumeCreateCommand.() -> Unit = {}): String {
+            return VolumeCreateCommand(executor).apply(configure).executeBlocking()
+        }
+
+        /**
+         * List volumes.
+         *
+         * @param configure Configuration block
+         * @return List of volumes
+         */
+        suspend fun ls(configure: VolumeLsCommand.() -> Unit = {}): List<VolumeSummary> {
+            return VolumeLsCommand(executor).apply(configure).execute()
+        }
+
+        /**
+         * List volumes (blocking).
+         */
+        fun lsBlocking(configure: VolumeLsCommand.() -> Unit = {}): List<VolumeSummary> {
+            return VolumeLsCommand(executor).apply(configure).executeBlocking()
+        }
+
+        /**
+         * Remove a volume.
+         *
+         * @param name Volume name
+         * @param configure Configuration block
+         */
+        suspend fun rm(name: String, configure: VolumeRmCommand.() -> Unit = {}) {
+            VolumeRmCommand(name, executor).apply(configure).execute()
+        }
+
+        /**
+         * Remove a volume (blocking).
+         */
+        fun rmBlocking(name: String, configure: VolumeRmCommand.() -> Unit = {}) {
+            VolumeRmCommand(name, executor).apply(configure).executeBlocking()
+        }
     }
 
     companion object {

--- a/docker-kotlin-core/src/main/kotlin/io/github/joshrotenberg/dockerkotlin/core/command/volume/VolumeLsCommand.kt
+++ b/docker-kotlin-core/src/main/kotlin/io/github/joshrotenberg/dockerkotlin/core/command/volume/VolumeLsCommand.kt
@@ -2,6 +2,10 @@ package io.github.joshrotenberg.dockerkotlin.core.command.volume
 
 import io.github.joshrotenberg.dockerkotlin.core.CommandExecutor
 import io.github.joshrotenberg.dockerkotlin.core.command.AbstractDockerCommand
+import io.github.joshrotenberg.dockerkotlin.core.model.VolumeSummary
+import kotlinx.serialization.json.Json
+
+private val json = Json { ignoreUnknownKeys = true }
 
 /**
  * Command to list Docker volumes.
@@ -10,17 +14,16 @@ import io.github.joshrotenberg.dockerkotlin.core.command.AbstractDockerCommand
  *
  * Example usage:
  * ```kotlin
- * VolumeLsCommand()
- *     .driverFilter("local")
- *     .executeBlocking()
+ * val volumes = VolumeLsCommand().execute()
+ * val localVolumes = VolumeLsCommand().driverFilter("local").execute()
  * ```
  */
 class VolumeLsCommand(
     executor: CommandExecutor = CommandExecutor()
-) : AbstractDockerCommand<String>(executor) {
+) : AbstractDockerCommand<List<VolumeSummary>>(executor) {
 
     private val filters = mutableMapOf<String, String>()
-    private var format: String? = null
+    private var customFormat: String? = null
     private var quiet = false
 
     /** Add a filter. */
@@ -38,11 +41,8 @@ class VolumeLsCommand(
     /** Filter dangling volumes. */
     fun danglingFilter(dangling: Boolean = true) = apply { filter("dangling", dangling.toString()) }
 
-    /** Set output format. */
-    fun format(format: String) = apply { this.format = format }
-
-    /** Format output as JSON. */
-    fun formatJson() = apply { format = "json" }
+    /** Set output format (overrides JSON output). */
+    fun format(format: String) = apply { this.customFormat = format }
 
     /** Only display volume names. */
     fun quiet() = apply { quiet = true }
@@ -56,16 +56,76 @@ class VolumeLsCommand(
             add("$key=$value")
         }
 
-        format?.let { add("--format"); add(it) }
+        // Use JSON format unless custom format or quiet is specified
+        if (customFormat != null) {
+            add("--format"); add(customFormat!!)
+        } else if (!quiet) {
+            add("--format"); add("json")
+        }
         if (quiet) add("--quiet")
     }
 
-    override suspend fun execute(): String {
-        return executeRaw().stdout
+    override suspend fun execute(): List<VolumeSummary> {
+        return parseJsonOutput(executeRaw().stdout)
     }
 
-    override fun executeBlocking(): String {
-        return executeRawBlocking().stdout
+    override fun executeBlocking(): List<VolumeSummary> {
+        return parseJsonOutput(executeRawBlocking().stdout)
+    }
+
+    /**
+     * Execute and return only volume names.
+     */
+    suspend fun executeNames(): List<String> {
+        val originalQuiet = quiet
+        quiet = true
+        val output = executeRaw()
+        quiet = originalQuiet
+        return output.stdout.lines().filter { it.isNotBlank() }.map { it.trim() }
+    }
+
+    /**
+     * Execute and return only volume names (blocking).
+     */
+    fun executeNamesBlocking(): List<String> {
+        val originalQuiet = quiet
+        quiet = true
+        val output = executeRawBlocking()
+        quiet = originalQuiet
+        return output.stdout.lines().filter { it.isNotBlank() }.map { it.trim() }
+    }
+
+    /**
+     * Execute with custom format and return raw string output.
+     */
+    suspend fun executeRawFormat(format: String): String {
+        val originalFormat = customFormat
+        customFormat = format
+        val output = executeRaw()
+        customFormat = originalFormat
+        return output.stdout
+    }
+
+    /**
+     * Execute with custom format and return raw string output (blocking).
+     */
+    fun executeRawFormatBlocking(format: String): String {
+        val originalFormat = customFormat
+        customFormat = format
+        val output = executeRawBlocking()
+        customFormat = originalFormat
+        return output.stdout
+    }
+
+    private fun parseJsonOutput(stdout: String): List<VolumeSummary> {
+        val lines = stdout.lines().filter { it.isNotBlank() }
+        if (lines.isEmpty()) return emptyList()
+
+        return lines.mapNotNull { line ->
+            runCatching {
+                json.decodeFromString<VolumeSummary>(line)
+            }.getOrNull()
+        }
     }
 
     companion object {

--- a/docker-kotlin-core/src/main/kotlin/io/github/joshrotenberg/dockerkotlin/core/model/ContainerSummary.kt
+++ b/docker-kotlin-core/src/main/kotlin/io/github/joshrotenberg/dockerkotlin/core/model/ContainerSummary.kt
@@ -1,0 +1,73 @@
+package io.github.joshrotenberg.dockerkotlin.core.model
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/**
+ * Summary information about a container from `docker ps`.
+ */
+@Serializable
+data class ContainerSummary(
+    @SerialName("ID")
+    val id: String,
+
+    @SerialName("Names")
+    val names: String,
+
+    @SerialName("Image")
+    val image: String,
+
+    @SerialName("Command")
+    val command: String,
+
+    @SerialName("CreatedAt")
+    val createdAt: String,
+
+    @SerialName("State")
+    val state: String,
+
+    @SerialName("Status")
+    val status: String,
+
+    @SerialName("Ports")
+    val ports: String = "",
+
+    @SerialName("Labels")
+    val labels: String = "",
+
+    @SerialName("Mounts")
+    val mounts: String = "",
+
+    @SerialName("Networks")
+    val networks: String = "",
+
+    @SerialName("Size")
+    val size: String = "",
+
+    @SerialName("RunningFor")
+    val runningFor: String = "",
+
+    @SerialName("LocalVolumes")
+    val localVolumes: String = ""
+) {
+    /** Whether the container is running. */
+    val isRunning: Boolean get() = state == "running"
+
+    /** Whether the container is exited. */
+    val isExited: Boolean get() = state == "exited"
+
+    /** Whether the container is paused. */
+    val isPaused: Boolean get() = state == "paused"
+
+    /** Get the container name (without leading slash). */
+    val name: String get() = names.removePrefix("/")
+
+    /** Get labels as a map. */
+    fun labelsMap(): Map<String, String> {
+        if (labels.isBlank()) return emptyMap()
+        return labels.split(",").mapNotNull { label ->
+            val parts = label.split("=", limit = 2)
+            if (parts.size == 2) parts[0] to parts[1] else null
+        }.toMap()
+    }
+}

--- a/docker-kotlin-core/src/main/kotlin/io/github/joshrotenberg/dockerkotlin/core/model/DockerInfo.kt
+++ b/docker-kotlin-core/src/main/kotlin/io/github/joshrotenberg/dockerkotlin/core/model/DockerInfo.kt
@@ -1,0 +1,136 @@
+package io.github.joshrotenberg.dockerkotlin.core.model
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/**
+ * Docker system information from `docker info --format json`.
+ */
+@Serializable
+data class DockerInfo(
+    @SerialName("ID")
+    val id: String,
+
+    @SerialName("Containers")
+    val containers: Int,
+
+    @SerialName("ContainersRunning")
+    val containersRunning: Int,
+
+    @SerialName("ContainersPaused")
+    val containersPaused: Int,
+
+    @SerialName("ContainersStopped")
+    val containersStopped: Int,
+
+    @SerialName("Images")
+    val images: Int,
+
+    @SerialName("Driver")
+    val driver: String,
+
+    @SerialName("MemoryLimit")
+    val memoryLimit: Boolean = false,
+
+    @SerialName("SwapLimit")
+    val swapLimit: Boolean = false,
+
+    @SerialName("CpuCfsPeriod")
+    val cpuCfsPeriod: Boolean = false,
+
+    @SerialName("CpuCfsQuota")
+    val cpuCfsQuota: Boolean = false,
+
+    @SerialName("CPUShares")
+    val cpuShares: Boolean = false,
+
+    @SerialName("CPUSet")
+    val cpuSet: Boolean = false,
+
+    @SerialName("PidsLimit")
+    val pidsLimit: Boolean = false,
+
+    @SerialName("IPv4Forwarding")
+    val ipv4Forwarding: Boolean = false,
+
+    @SerialName("Debug")
+    val debug: Boolean = false,
+
+    @SerialName("NFd")
+    val nFd: Int = 0,
+
+    @SerialName("OomKillDisable")
+    val oomKillDisable: Boolean = false,
+
+    @SerialName("NGoroutines")
+    val nGoroutines: Int = 0,
+
+    @SerialName("SystemTime")
+    val systemTime: String = "",
+
+    @SerialName("LoggingDriver")
+    val loggingDriver: String = "",
+
+    @SerialName("CgroupDriver")
+    val cgroupDriver: String = "",
+
+    @SerialName("CgroupVersion")
+    val cgroupVersion: String = "",
+
+    @SerialName("NEventsListener")
+    val nEventsListener: Int = 0,
+
+    @SerialName("KernelVersion")
+    val kernelVersion: String = "",
+
+    @SerialName("OperatingSystem")
+    val operatingSystem: String = "",
+
+    @SerialName("OSVersion")
+    val osVersion: String = "",
+
+    @SerialName("OSType")
+    val osType: String = "",
+
+    @SerialName("Architecture")
+    val architecture: String = "",
+
+    @SerialName("IndexServerAddress")
+    val indexServerAddress: String = "",
+
+    @SerialName("NCPU")
+    val ncpu: Int = 0,
+
+    @SerialName("MemTotal")
+    val memTotal: Long = 0,
+
+    @SerialName("DockerRootDir")
+    val dockerRootDir: String = "",
+
+    @SerialName("Name")
+    val name: String = "",
+
+    @SerialName("ServerVersion")
+    val serverVersion: String = "",
+
+    @SerialName("Plugins")
+    val plugins: DockerPlugins? = null
+)
+
+/**
+ * Docker plugin information.
+ */
+@Serializable
+data class DockerPlugins(
+    @SerialName("Volume")
+    val volume: List<String> = emptyList(),
+
+    @SerialName("Network")
+    val network: List<String> = emptyList(),
+
+    @SerialName("Authorization")
+    val authorization: List<String>? = null,
+
+    @SerialName("Log")
+    val log: List<String> = emptyList()
+)

--- a/docker-kotlin-core/src/main/kotlin/io/github/joshrotenberg/dockerkotlin/core/model/DockerVersion.kt
+++ b/docker-kotlin-core/src/main/kotlin/io/github/joshrotenberg/dockerkotlin/core/model/DockerVersion.kt
@@ -1,0 +1,112 @@
+package io.github.joshrotenberg.dockerkotlin.core.model
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/**
+ * Docker version information from `docker version --format json`.
+ */
+@Serializable
+data class DockerVersion(
+    @SerialName("Client")
+    val client: ClientVersion,
+
+    @SerialName("Server")
+    val server: ServerVersion? = null
+)
+
+/**
+ * Docker client version information.
+ */
+@Serializable
+data class ClientVersion(
+    @SerialName("Version")
+    val version: String,
+
+    @SerialName("ApiVersion")
+    val apiVersion: String,
+
+    @SerialName("DefaultAPIVersion")
+    val defaultApiVersion: String = "",
+
+    @SerialName("GitCommit")
+    val gitCommit: String = "",
+
+    @SerialName("GoVersion")
+    val goVersion: String = "",
+
+    @SerialName("Os")
+    val os: String = "",
+
+    @SerialName("Arch")
+    val arch: String = "",
+
+    @SerialName("BuildTime")
+    val buildTime: String = "",
+
+    @SerialName("Context")
+    val context: String = ""
+)
+
+/**
+ * Docker server version information.
+ */
+@Serializable
+data class ServerVersion(
+    @SerialName("Platform")
+    val platform: ServerPlatform? = null,
+
+    @SerialName("Version")
+    val version: String,
+
+    @SerialName("ApiVersion")
+    val apiVersion: String,
+
+    @SerialName("MinAPIVersion")
+    val minApiVersion: String = "",
+
+    @SerialName("Os")
+    val os: String = "",
+
+    @SerialName("Arch")
+    val arch: String = "",
+
+    @SerialName("GitCommit")
+    val gitCommit: String = "",
+
+    @SerialName("GoVersion")
+    val goVersion: String = "",
+
+    @SerialName("KernelVersion")
+    val kernelVersion: String = "",
+
+    @SerialName("BuildTime")
+    val buildTime: String = "",
+
+    @SerialName("Components")
+    val components: List<ServerComponent> = emptyList()
+)
+
+/**
+ * Docker server platform information.
+ */
+@Serializable
+data class ServerPlatform(
+    @SerialName("Name")
+    val name: String
+)
+
+/**
+ * Docker server component information.
+ */
+@Serializable
+data class ServerComponent(
+    @SerialName("Name")
+    val name: String,
+
+    @SerialName("Version")
+    val version: String,
+
+    @SerialName("Details")
+    val details: Map<String, String> = emptyMap()
+)

--- a/docker-kotlin-core/src/main/kotlin/io/github/joshrotenberg/dockerkotlin/core/model/ImageSummary.kt
+++ b/docker-kotlin-core/src/main/kotlin/io/github/joshrotenberg/dockerkotlin/core/model/ImageSummary.kt
@@ -1,0 +1,46 @@
+package io.github.joshrotenberg.dockerkotlin.core.model
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/**
+ * Summary information about an image from `docker images`.
+ */
+@Serializable
+data class ImageSummary(
+    @SerialName("ID")
+    val id: String,
+
+    @SerialName("Repository")
+    val repository: String,
+
+    @SerialName("Tag")
+    val tag: String,
+
+    @SerialName("CreatedAt")
+    val createdAt: String,
+
+    @SerialName("CreatedSince")
+    val createdSince: String = "",
+
+    @SerialName("Size")
+    val size: String,
+
+    @SerialName("Digest")
+    val digest: String = "",
+
+    @SerialName("Containers")
+    val containers: String = "",
+
+    @SerialName("SharedSize")
+    val sharedSize: String = "",
+
+    @SerialName("UniqueSize")
+    val uniqueSize: String = ""
+) {
+    /** The full image reference (repository:tag). */
+    val reference: String get() = if (tag.isNotBlank() && tag != "<none>") "$repository:$tag" else repository
+
+    /** Whether this is a dangling image (no tag). */
+    val isDangling: Boolean get() = tag == "<none>" || repository == "<none>"
+}

--- a/docker-kotlin-core/src/main/kotlin/io/github/joshrotenberg/dockerkotlin/core/model/NetworkSummary.kt
+++ b/docker-kotlin-core/src/main/kotlin/io/github/joshrotenberg/dockerkotlin/core/model/NetworkSummary.kt
@@ -1,0 +1,46 @@
+package io.github.joshrotenberg.dockerkotlin.core.model
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/**
+ * Summary information about a network from `docker network ls`.
+ */
+@Serializable
+data class NetworkSummary(
+    @SerialName("ID")
+    val id: String,
+
+    @SerialName("Name")
+    val name: String,
+
+    @SerialName("Driver")
+    val driver: String,
+
+    @SerialName("Scope")
+    val scope: String,
+
+    @SerialName("CreatedAt")
+    val createdAt: String = "",
+
+    @SerialName("IPv4")
+    val ipv4: String = "",
+
+    @SerialName("IPv6")
+    val ipv6: String = "",
+
+    @SerialName("Internal")
+    val internal: String = "",
+
+    @SerialName("Labels")
+    val labels: String = ""
+) {
+    /** Whether IPv4 is enabled. */
+    val ipv4Enabled: Boolean get() = ipv4 == "true"
+
+    /** Whether IPv6 is enabled. */
+    val ipv6Enabled: Boolean get() = ipv6 == "true"
+
+    /** Whether this is an internal network. */
+    val isInternal: Boolean get() = internal == "true"
+}

--- a/docker-kotlin-core/src/main/kotlin/io/github/joshrotenberg/dockerkotlin/core/model/VolumeSummary.kt
+++ b/docker-kotlin-core/src/main/kotlin/io/github/joshrotenberg/dockerkotlin/core/model/VolumeSummary.kt
@@ -1,0 +1,40 @@
+package io.github.joshrotenberg.dockerkotlin.core.model
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/**
+ * Summary information about a volume from `docker volume ls`.
+ */
+@Serializable
+data class VolumeSummary(
+    @SerialName("Name")
+    val name: String,
+
+    @SerialName("Driver")
+    val driver: String,
+
+    @SerialName("Scope")
+    val scope: String = "",
+
+    @SerialName("Mountpoint")
+    val mountpoint: String = "",
+
+    @SerialName("Labels")
+    val labels: String = "",
+
+    @SerialName("Size")
+    val size: String = "",
+
+    @SerialName("Links")
+    val links: String = "",
+
+    @SerialName("Availability")
+    val availability: String = "",
+
+    @SerialName("Group")
+    val group: String = "",
+
+    @SerialName("Status")
+    val status: String = ""
+)

--- a/docker-kotlin-core/src/test/kotlin/io/github/joshrotenberg/dockerkotlin/core/command/ImageCommandsTest.kt
+++ b/docker-kotlin-core/src/test/kotlin/io/github/joshrotenberg/dockerkotlin/core/command/ImageCommandsTest.kt
@@ -12,7 +12,11 @@ class ImageCommandsTest {
     @Test
     fun `ImagesCommand buildArgs basic`() {
         val cmd = ImagesCommand()
-        assertEquals(listOf("images"), cmd.buildArgs())
+        val args = cmd.buildArgs()
+        assertEquals("images", args[0])
+        // Default format is json
+        assertTrue(args.contains("--format"))
+        assertTrue(args.contains("json"))
     }
 
     @Test

--- a/docker-kotlin-core/src/test/kotlin/io/github/joshrotenberg/dockerkotlin/core/command/VersionCommandTest.kt
+++ b/docker-kotlin-core/src/test/kotlin/io/github/joshrotenberg/dockerkotlin/core/command/VersionCommandTest.kt
@@ -2,16 +2,21 @@ package io.github.joshrotenberg.dockerkotlin.core.command
 
 import org.junit.jupiter.api.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertTrue
 
 class VersionCommandTest {
 
     @Test
-    fun `buildArgs returns version command`() {
+    fun `buildArgs returns version command with json format`() {
         val cmd = VersionCommand()
-        assertEquals(listOf("version"), cmd.buildArgs())
+        val args = cmd.buildArgs()
+        assertEquals("version", args[0])
+        assertTrue(args.contains("--format"))
+        assertTrue(args.contains("json"))
     }
 
     @Test
+    @Suppress("DEPRECATION")
     fun `parse extracts version info from docker output`() {
         val output = """
             Client:
@@ -45,6 +50,7 @@ class VersionCommandTest {
     }
 
     @Test
+    @Suppress("DEPRECATION")
     fun `parse handles missing server info`() {
         val output = """
             Client:

--- a/docker-kotlin-core/src/test/kotlin/io/github/joshrotenberg/dockerkotlin/core/command/network/NetworkCommandsTest.kt
+++ b/docker-kotlin-core/src/test/kotlin/io/github/joshrotenberg/dockerkotlin/core/command/network/NetworkCommandsTest.kt
@@ -64,7 +64,12 @@ class NetworkCommandsTest {
     @Test
     fun `NetworkLsCommand buildArgs basic`() {
         val cmd = NetworkLsCommand()
-        assertEquals(listOf("network", "ls"), cmd.buildArgs())
+        val args = cmd.buildArgs()
+        assertEquals("network", args[0])
+        assertEquals("ls", args[1])
+        // Default format is json
+        assertTrue(args.contains("--format"))
+        assertTrue(args.contains("json"))
     }
 
     @Test
@@ -81,7 +86,15 @@ class NetworkCommandsTest {
 
     @Test
     fun `NetworkLsCommand buildArgs with format`() {
-        val cmd = NetworkLsCommand().formatJson()
+        val cmd = NetworkLsCommand().format("{{.Name}}")
+        val args = cmd.buildArgs()
+        assertTrue(args.contains("--format"))
+        assertTrue(args.contains("{{.Name}}"))
+    }
+
+    @Test
+    fun `NetworkLsCommand buildArgs default uses json format`() {
+        val cmd = NetworkLsCommand()
         val args = cmd.buildArgs()
         assertTrue(args.contains("--format"))
         assertTrue(args.contains("json"))

--- a/docker-kotlin-core/src/test/kotlin/io/github/joshrotenberg/dockerkotlin/core/command/volume/VolumeCommandsTest.kt
+++ b/docker-kotlin-core/src/test/kotlin/io/github/joshrotenberg/dockerkotlin/core/command/volume/VolumeCommandsTest.kt
@@ -59,7 +59,12 @@ class VolumeCommandsTest {
     @Test
     fun `VolumeLsCommand buildArgs basic`() {
         val cmd = VolumeLsCommand()
-        assertEquals(listOf("volume", "ls"), cmd.buildArgs())
+        val args = cmd.buildArgs()
+        assertEquals("volume", args[0])
+        assertEquals("ls", args[1])
+        // Default format is json
+        assertTrue(args.contains("--format"))
+        assertTrue(args.contains("json"))
     }
 
     @Test
@@ -82,8 +87,16 @@ class VolumeCommandsTest {
     }
 
     @Test
-    fun `VolumeLsCommand buildArgs format json`() {
-        val cmd = VolumeLsCommand().formatJson()
+    fun `VolumeLsCommand buildArgs format custom`() {
+        val cmd = VolumeLsCommand().format("{{.Name}}")
+        val args = cmd.buildArgs()
+        assertTrue(args.contains("--format"))
+        assertTrue(args.contains("{{.Name}}"))
+    }
+
+    @Test
+    fun `VolumeLsCommand buildArgs default uses json format`() {
+        val cmd = VolumeLsCommand()
         val args = cmd.buildArgs()
         assertTrue(args.contains("--format"))
         assertTrue(args.contains("json"))

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,7 @@
 [versions]
 kotlin = "2.1.0"
 coroutines = "1.9.0"
+serialization = "1.7.3"
 slf4j = "2.0.16"
 logback = "1.5.12"
 junit-jupiter = "5.11.4"
@@ -16,6 +17,9 @@ kotlin-test = { module = "org.jetbrains.kotlin:kotlin-test", version.ref = "kotl
 coroutines-bom = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-bom", version.ref = "coroutines" }
 coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core" }
 coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test" }
+
+# Serialization
+serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "serialization" }
 
 # Logging
 slf4j-api = { module = "org.slf4j:slf4j-api", version.ref = "slf4j" }
@@ -36,3 +40,4 @@ testing = ["kotlin-test", "coroutines-test", "junit-jupiter"]
 
 [plugins]
 kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
+kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }


### PR DESCRIPTION
## Summary

This PR adds typed response classes, completes the Docker.kt facade, and fixes async timeout handling.

## Changes

### Typed Response Classes (#20)
Added kotlinx-serialization and typed response models for commands that return structured data:
- `ContainerSummary` - for `docker ps`
- `ImageSummary` - for `docker images`
- `NetworkSummary` - for `docker network ls`
- `VolumeSummary` - for `docker volume ls`
- `DockerVersion` - for `docker version`
- `DockerInfo` - for `docker info`

Commands now use `--format json` and parse responses into typed objects.

### Docker.kt Facade (#27)
Completed the Docker.kt facade with all major commands:
- **System**: `version()`, `info()`
- **Container**: `run()`, `start()`, `stop()`, `rm()`, `ps()`, `exec()`, `logs()`, `inspect()`
- **Image**: `pull()`, `push()`, `build()`, `images()`, `rmi()`, `tag()`
- **Network**: `docker.network.create()`, `docker.network.ls()`, `docker.network.rm()`
- **Volume**: `docker.volume.create()`, `docker.volume.ls()`, `docker.volume.rm()`

### Timeout Behavior Fix (#29)
Fixed async command execution to properly clean up processes on timeout/cancellation:
- Changed from `withTimeoutOrNull` to `withTimeout` with proper exception handling
- Process is now forcibly destroyed and awaited on cancellation

## Testing
All 283+ tests pass.

Closes #20
Closes #27
Closes #29