### PR TITLE
feat: complete Docker command coverage

### DIFF
--- a/docker-kotlin-core/src/main/kotlin/io/github/joshrotenberg/dockerkotlin/core/command/config/ConfigCreateCommand.kt
+++ b/docker-kotlin-core/src/main/kotlin/io/github/joshrotenberg/dockerkotlin/core/command/config/ConfigCreateCommand.kt
@@ -1,0 +1,57 @@
+package io.github.joshrotenberg.dockerkotlin.core.command.config
+
+import io.github.joshrotenberg.dockerkotlin.core.CommandExecutor
+import io.github.joshrotenberg.dockerkotlin.core.command.AbstractDockerCommand
+
+/**
+ * Command to create a config from a file or STDIN.
+ *
+ * Equivalent to `docker config create`.
+ *
+ * Example usage:
+ * ```kotlin
+ * ConfigCreateCommand("my-config", "/path/to/config.json").executeBlocking()
+ * ConfigCreateCommand("my-config", "-").label("env", "prod").executeBlocking()
+ * ```
+ */
+class ConfigCreateCommand(
+    private val name: String,
+    private val file: String,
+    executor: CommandExecutor = CommandExecutor()
+) : AbstractDockerCommand<String>(executor) {
+
+    private val labels = mutableMapOf<String, String>()
+    private var templateDriver: String? = null
+
+    /** Add a label to the config. */
+    fun label(key: String, value: String) = apply { labels[key] = value }
+
+    /** Add multiple labels to the config. */
+    fun labels(labels: Map<String, String>) = apply { this.labels.putAll(labels) }
+
+    /** Template driver. */
+    fun templateDriver(driver: String) = apply { templateDriver = driver }
+
+    override fun buildArgs(): List<String> = buildList {
+        add("config")
+        add("create")
+        labels.forEach { (key, value) -> add("--label"); add("$key=$value") }
+        templateDriver?.let { add("--template-driver"); add(it) }
+        add(name)
+        add(file)
+    }
+
+    override suspend fun execute(): String {
+        return executeRaw().stdout.trim()
+    }
+
+    override fun executeBlocking(): String {
+        return executeRawBlocking().stdout.trim()
+    }
+
+    companion object {
+        @JvmStatic
+        fun builder(name: String, file: String): ConfigCreateCommand =
+            ConfigCreateCommand(name, file)
+    }
+}

--- a/docker-kotlin-core/src/main/kotlin/io/github/joshrotenberg/dockerkotlin/core/command/config/ConfigInspectCommand.kt
+++ b/docker-kotlin-core/src/main/kotlin/io/github/joshrotenberg/dockerkotlin/core/command/config/ConfigInspectCommand.kt
@@ -1,0 +1,61 @@
+package io.github.joshrotenberg.dockerkotlin.core.command.config
+
+import io.github.joshrotenberg.dockerkotlin.core.CommandExecutor
+import io.github.joshrotenberg.dockerkotlin.core.command.AbstractDockerCommand
+
+/**
+ * Command to display detailed information on one or more configs.
+ *
+ * Equivalent to `docker config inspect`.
+ *
+ * Example usage:
+ * ```kotlin
+ * ConfigInspectCommand("my-config").executeBlocking()
+ * ConfigInspectCommand("my-config").format("{{.ID}}").executeBlocking()
+ * ConfigInspectCommand(listOf("config1", "config2")).executeBlocking()
+ * ```
+ */
+class ConfigInspectCommand : AbstractDockerCommand<String> {
+
+    private val configs: List<String>
+    private var format: String? = null
+    private var pretty = false
+
+    constructor(config: String, executor: CommandExecutor = CommandExecutor()) : super(executor) {
+        this.configs = listOf(config)
+    }
+
+    constructor(configs: List<String>, executor: CommandExecutor = CommandExecutor()) : super(executor) {
+        this.configs = configs
+    }
+
+    /** Format output using a Go template. */
+    fun format(format: String) = apply { this.format = format }
+
+    /** Print the information in a human friendly format. */
+    fun pretty() = apply { pretty = true }
+
+    override fun buildArgs(): List<String> = buildList {
+        add("config")
+        add("inspect")
+        format?.let { add("--format"); add(it) }
+        if (pretty) add("--pretty")
+        addAll(configs)
+    }
+
+    override suspend fun execute(): String {
+        return executeRaw().stdout
+    }
+
+    override fun executeBlocking(): String {
+        return executeRawBlocking().stdout
+    }
+
+    companion object {
+        @JvmStatic
+        fun builder(config: String): ConfigInspectCommand = ConfigInspectCommand(config)
+
+        @JvmStatic
+        fun builder(configs: List<String>): ConfigInspectCommand = ConfigInspectCommand(configs)
+    }
+}

--- a/docker-kotlin-core/src/main/kotlin/io/github/joshrotenberg/dockerkotlin/core/command/config/ConfigLsCommand.kt
+++ b/docker-kotlin-core/src/main/kotlin/io/github/joshrotenberg/dockerkotlin/core/command/config/ConfigLsCommand.kt
@@ -1,0 +1,55 @@
+package io.github.joshrotenberg.dockerkotlin.core.command.config
+
+import io.github.joshrotenberg.dockerkotlin.core.CommandExecutor
+import io.github.joshrotenberg.dockerkotlin.core.command.AbstractDockerCommand
+
+/**
+ * Command to list configs.
+ *
+ * Equivalent to `docker config ls`.
+ *
+ * Example usage:
+ * ```kotlin
+ * ConfigLsCommand().executeBlocking()
+ * ConfigLsCommand().filter("name", "my-config").executeBlocking()
+ * ConfigLsCommand().quiet().executeBlocking()
+ * ```
+ */
+class ConfigLsCommand(
+    executor: CommandExecutor = CommandExecutor()
+) : AbstractDockerCommand<String>(executor) {
+
+    private val filters = mutableMapOf<String, String>()
+    private var format: String? = null
+    private var quiet = false
+
+    /** Filter output based on conditions provided. */
+    fun filter(key: String, value: String) = apply { filters[key] = value }
+
+    /** Format output using a Go template. */
+    fun format(format: String) = apply { this.format = format }
+
+    /** Only display config IDs. */
+    fun quiet() = apply { quiet = true }
+
+    override fun buildArgs(): List<String> = buildList {
+        add("config")
+        add("ls")
+        filters.forEach { (key, value) -> add("--filter"); add("$key=$value") }
+        format?.let { add("--format"); add(it) }
+        if (quiet) add("--quiet")
+    }
+
+    override suspend fun execute(): String {
+        return executeRaw().stdout
+    }
+
+    override fun executeBlocking(): String {
+        return executeRawBlocking().stdout
+    }
+
+    companion object {
+        @JvmStatic
+        fun builder(): ConfigLsCommand = ConfigLsCommand()
+    }
+}

--- a/docker-kotlin-core/src/main/kotlin/io/github/joshrotenberg/dockerkotlin/core/command/config/ConfigRmCommand.kt
+++ b/docker-kotlin-core/src/main/kotlin/io/github/joshrotenberg/dockerkotlin/core/command/config/ConfigRmCommand.kt
@@ -1,0 +1,50 @@
+package io.github.joshrotenberg.dockerkotlin.core.command.config
+
+import io.github.joshrotenberg.dockerkotlin.core.CommandExecutor
+import io.github.joshrotenberg.dockerkotlin.core.command.AbstractDockerCommand
+
+/**
+ * Command to remove one or more configs.
+ *
+ * Equivalent to `docker config rm`.
+ *
+ * Example usage:
+ * ```kotlin
+ * ConfigRmCommand("my-config").executeBlocking()
+ * ConfigRmCommand(listOf("config1", "config2")).executeBlocking()
+ * ```
+ */
+class ConfigRmCommand : AbstractDockerCommand<String> {
+
+    private val configs: List<String>
+
+    constructor(config: String, executor: CommandExecutor = CommandExecutor()) : super(executor) {
+        this.configs = listOf(config)
+    }
+
+    constructor(configs: List<String>, executor: CommandExecutor = CommandExecutor()) : super(executor) {
+        this.configs = configs
+    }
+
+    override fun buildArgs(): List<String> = buildList {
+        add("config")
+        add("rm")
+        addAll(configs)
+    }
+
+    override suspend fun execute(): String {
+        return executeRaw().stdout
+    }
+
+    override fun executeBlocking(): String {
+        return executeRawBlocking().stdout
+    }
+
+    companion object {
+        @JvmStatic
+        fun builder(config: String): ConfigRmCommand = ConfigRmCommand(config)
+
+        @JvmStatic
+        fun builder(configs: List<String>): ConfigRmCommand = ConfigRmCommand(configs)
+    }
+}

--- a/docker-kotlin-core/src/main/kotlin/io/github/joshrotenberg/dockerkotlin/core/command/image/ImageInspectCommand.kt
+++ b/docker-kotlin-core/src/main/kotlin/io/github/joshrotenberg/dockerkotlin/core/command/image/ImageInspectCommand.kt
@@ -1,0 +1,55 @@
+package io.github.joshrotenberg.dockerkotlin.core.command.image
+
+import io.github.joshrotenberg.dockerkotlin.core.CommandExecutor
+import io.github.joshrotenberg.dockerkotlin.core.command.AbstractDockerCommand
+
+/**
+ * Command to display detailed information on one or more images.
+ *
+ * Equivalent to `docker image inspect`.
+ *
+ * Example usage:
+ * ```kotlin
+ * ImageInspectCommand("nginx:latest").executeBlocking()
+ * ImageInspectCommand("nginx:latest").format("{{.Id}}").executeBlocking()
+ * ```
+ */
+class ImageInspectCommand : AbstractDockerCommand<String> {
+
+    private val images: List<String>
+    private var format: String? = null
+
+    constructor(image: String, executor: CommandExecutor = CommandExecutor()) : super(executor) {
+        this.images = listOf(image)
+    }
+
+    constructor(images: List<String>, executor: CommandExecutor = CommandExecutor()) : super(executor) {
+        this.images = images
+    }
+
+    /** Set output format using Go template. */
+    fun format(format: String) = apply { this.format = format }
+
+    override fun buildArgs(): List<String> = buildList {
+        add("image")
+        add("inspect")
+        format?.let { add("--format"); add(it) }
+        addAll(images)
+    }
+
+    override suspend fun execute(): String {
+        return executeRaw().stdout
+    }
+
+    override fun executeBlocking(): String {
+        return executeRawBlocking().stdout
+    }
+
+    companion object {
+        @JvmStatic
+        fun builder(image: String): ImageInspectCommand = ImageInspectCommand(image)
+
+        @JvmStatic
+        fun builder(images: List<String>): ImageInspectCommand = ImageInspectCommand(images)
+    }
+}

--- a/docker-kotlin-core/src/main/kotlin/io/github/joshrotenberg/dockerkotlin/core/command/node/NodeDemoteCommand.kt
+++ b/docker-kotlin-core/src/main/kotlin/io/github/joshrotenberg/dockerkotlin/core/command/node/NodeDemoteCommand.kt
@@ -1,0 +1,50 @@
+package io.github.joshrotenberg.dockerkotlin.core.command.node
+
+import io.github.joshrotenberg.dockerkotlin.core.CommandExecutor
+import io.github.joshrotenberg.dockerkotlin.core.command.AbstractDockerCommand
+
+/**
+ * Command to demote one or more nodes from manager in the swarm.
+ *
+ * Equivalent to `docker node demote`.
+ *
+ * Example usage:
+ * ```kotlin
+ * NodeDemoteCommand("node1").executeBlocking()
+ * NodeDemoteCommand(listOf("node1", "node2")).executeBlocking()
+ * ```
+ */
+class NodeDemoteCommand : AbstractDockerCommand<String> {
+
+    private val nodes: List<String>
+
+    constructor(node: String, executor: CommandExecutor = CommandExecutor()) : super(executor) {
+        this.nodes = listOf(node)
+    }
+
+    constructor(nodes: List<String>, executor: CommandExecutor = CommandExecutor()) : super(executor) {
+        this.nodes = nodes
+    }
+
+    override fun buildArgs(): List<String> = buildList {
+        add("node")
+        add("demote")
+        addAll(nodes)
+    }
+
+    override suspend fun execute(): String {
+        return executeRaw().stdout
+    }
+
+    override fun executeBlocking(): String {
+        return executeRawBlocking().stdout
+    }
+
+    companion object {
+        @JvmStatic
+        fun builder(node: String): NodeDemoteCommand = NodeDemoteCommand(node)
+
+        @JvmStatic
+        fun builder(nodes: List<String>): NodeDemoteCommand = NodeDemoteCommand(nodes)
+    }
+}

--- a/docker-kotlin-core/src/main/kotlin/io/github/joshrotenberg/dockerkotlin/core/command/node/NodeInspectCommand.kt
+++ b/docker-kotlin-core/src/main/kotlin/io/github/joshrotenberg/dockerkotlin/core/command/node/NodeInspectCommand.kt
@@ -1,0 +1,61 @@
+package io.github.joshrotenberg.dockerkotlin.core.command.node
+
+import io.github.joshrotenberg.dockerkotlin.core.CommandExecutor
+import io.github.joshrotenberg.dockerkotlin.core.command.AbstractDockerCommand
+
+/**
+ * Command to display detailed information on one or more nodes.
+ *
+ * Equivalent to `docker node inspect`.
+ *
+ * Example usage:
+ * ```kotlin
+ * NodeInspectCommand("node1").executeBlocking()
+ * NodeInspectCommand("node1").pretty().executeBlocking()
+ * NodeInspectCommand("self").format("{{.ID}}").executeBlocking()
+ * ```
+ */
+class NodeInspectCommand : AbstractDockerCommand<String> {
+
+    private val nodes: List<String>
+    private var format: String? = null
+    private var pretty = false
+
+    constructor(node: String, executor: CommandExecutor = CommandExecutor()) : super(executor) {
+        this.nodes = listOf(node)
+    }
+
+    constructor(nodes: List<String>, executor: CommandExecutor = CommandExecutor()) : super(executor) {
+        this.nodes = nodes
+    }
+
+    /** Format output using a Go template. */
+    fun format(format: String) = apply { this.format = format }
+
+    /** Print the information in a human friendly format. */
+    fun pretty() = apply { pretty = true }
+
+    override fun buildArgs(): List<String> = buildList {
+        add("node")
+        add("inspect")
+        format?.let { add("--format"); add(it) }
+        if (pretty) add("--pretty")
+        addAll(nodes)
+    }
+
+    override suspend fun execute(): String {
+        return executeRaw().stdout
+    }
+
+    override fun executeBlocking(): String {
+        return executeRawBlocking().stdout
+    }
+
+    companion object {
+        @JvmStatic
+        fun builder(node: String): NodeInspectCommand = NodeInspectCommand(node)
+
+        @JvmStatic
+        fun builder(nodes: List<String>): NodeInspectCommand = NodeInspectCommand(nodes)
+    }
+}

--- a/docker-kotlin-core/src/main/kotlin/io/github/joshrotenberg/dockerkotlin/core/command/node/NodeLsCommand.kt
+++ b/docker-kotlin-core/src/main/kotlin/io/github/joshrotenberg/dockerkotlin/core/command/node/NodeLsCommand.kt
@@ -1,0 +1,55 @@
+package io.github.joshrotenberg.dockerkotlin.core.command.node
+
+import io.github.joshrotenberg.dockerkotlin.core.CommandExecutor
+import io.github.joshrotenberg.dockerkotlin.core.command.AbstractDockerCommand
+
+/**
+ * Command to list nodes in the swarm.
+ *
+ * Equivalent to `docker node ls`.
+ *
+ * Example usage:
+ * ```kotlin
+ * NodeLsCommand().executeBlocking()
+ * NodeLsCommand().filter("role", "manager").executeBlocking()
+ * NodeLsCommand().quiet().executeBlocking()
+ * ```
+ */
+class NodeLsCommand(
+    executor: CommandExecutor = CommandExecutor()
+) : AbstractDockerCommand<String>(executor) {
+
+    private val filters = mutableMapOf<String, String>()
+    private var format: String? = null
+    private var quiet = false
+
+    /** Filter output based on conditions provided. */
+    fun filter(key: String, value: String) = apply { filters[key] = value }
+
+    /** Format output using a Go template. */
+    fun format(format: String) = apply { this.format = format }
+
+    /** Only display node IDs. */
+    fun quiet() = apply { quiet = true }
+
+    override fun buildArgs(): List<String> = buildList {
+        add("node")
+        add("ls")
+        filters.forEach { (key, value) -> add("--filter"); add("$key=$value") }
+        format?.let { add("--format"); add(it) }
+        if (quiet) add("--quiet")
+    }
+
+    override suspend fun execute(): String {
+        return executeRaw().stdout
+    }
+
+    override fun executeBlocking(): String {
+        return executeRawBlocking().stdout
+    }
+
+    companion object {
+        @JvmStatic
+        fun builder(): NodeLsCommand = NodeLsCommand()
+    }
+}

--- a/docker-kotlin-core/src/main/kotlin/io/github/joshrotenberg/dockerkotlin/core/command/node/NodePromoteCommand.kt
+++ b/docker-kotlin-core/src/main/kotlin/io/github/joshrotenberg/dockerkotlin/core/command/node/NodePromoteCommand.kt
@@ -1,0 +1,50 @@
+package io.github.joshrotenberg.dockerkotlin.core.command.node
+
+import io.github.joshrotenberg.dockerkotlin.core.CommandExecutor
+import io.github.joshrotenberg.dockerkotlin.core.command.AbstractDockerCommand
+
+/**
+ * Command to promote one or more nodes to manager in the swarm.
+ *
+ * Equivalent to `docker node promote`.
+ *
+ * Example usage:
+ * ```kotlin
+ * NodePromoteCommand("node1").executeBlocking()
+ * NodePromoteCommand(listOf("node1", "node2")).executeBlocking()
+ * ```
+ */
+class NodePromoteCommand : AbstractDockerCommand<String> {
+
+    private val nodes: List<String>
+
+    constructor(node: String, executor: CommandExecutor = CommandExecutor()) : super(executor) {
+        this.nodes = listOf(node)
+    }
+
+    constructor(nodes: List<String>, executor: CommandExecutor = CommandExecutor()) : super(executor) {
+        this.nodes = nodes
+    }
+
+    override fun buildArgs(): List<String> = buildList {
+        add("node")
+        add("promote")
+        addAll(nodes)
+    }
+
+    override suspend fun execute(): String {
+        return executeRaw().stdout
+    }
+
+    override fun executeBlocking(): String {
+        return executeRawBlocking().stdout
+    }
+
+    companion object {
+        @JvmStatic
+        fun builder(node: String): NodePromoteCommand = NodePromoteCommand(node)
+
+        @JvmStatic
+        fun builder(nodes: List<String>): NodePromoteCommand = NodePromoteCommand(nodes)
+    }
+}

--- a/docker-kotlin-core/src/main/kotlin/io/github/joshrotenberg/dockerkotlin/core/command/node/NodePsCommand.kt
+++ b/docker-kotlin-core/src/main/kotlin/io/github/joshrotenberg/dockerkotlin/core/command/node/NodePsCommand.kt
@@ -1,0 +1,83 @@
+package io.github.joshrotenberg.dockerkotlin.core.command.node
+
+import io.github.joshrotenberg.dockerkotlin.core.CommandExecutor
+import io.github.joshrotenberg.dockerkotlin.core.command.AbstractDockerCommand
+
+/**
+ * Command to list tasks running on one or more nodes.
+ *
+ * Equivalent to `docker node ps`.
+ *
+ * Example usage:
+ * ```kotlin
+ * NodePsCommand().executeBlocking()  // defaults to self
+ * NodePsCommand("node1").executeBlocking()
+ * NodePsCommand(listOf("node1", "node2")).filter("desired-state", "running").executeBlocking()
+ * ```
+ */
+class NodePsCommand : AbstractDockerCommand<String> {
+
+    private val nodes: List<String>
+    private val filters = mutableMapOf<String, String>()
+    private var format: String? = null
+    private var noResolve = false
+    private var noTrunc = false
+    private var quiet = false
+
+    constructor(executor: CommandExecutor = CommandExecutor()) : super(executor) {
+        this.nodes = emptyList()
+    }
+
+    constructor(node: String, executor: CommandExecutor = CommandExecutor()) : super(executor) {
+        this.nodes = listOf(node)
+    }
+
+    constructor(nodes: List<String>, executor: CommandExecutor = CommandExecutor()) : super(executor) {
+        this.nodes = nodes
+    }
+
+    /** Filter output based on conditions provided. */
+    fun filter(key: String, value: String) = apply { filters[key] = value }
+
+    /** Format output using a Go template. */
+    fun format(format: String) = apply { this.format = format }
+
+    /** Do not map IDs to names. */
+    fun noResolve() = apply { noResolve = true }
+
+    /** Do not truncate output. */
+    fun noTrunc() = apply { noTrunc = true }
+
+    /** Only display task IDs. */
+    fun quiet() = apply { quiet = true }
+
+    override fun buildArgs(): List<String> = buildList {
+        add("node")
+        add("ps")
+        filters.forEach { (key, value) -> add("--filter"); add("$key=$value") }
+        format?.let { add("--format"); add(it) }
+        if (noResolve) add("--no-resolve")
+        if (noTrunc) add("--no-trunc")
+        if (quiet) add("--quiet")
+        addAll(nodes)
+    }
+
+    override suspend fun execute(): String {
+        return executeRaw().stdout
+    }
+
+    override fun executeBlocking(): String {
+        return executeRawBlocking().stdout
+    }
+
+    companion object {
+        @JvmStatic
+        fun builder(): NodePsCommand = NodePsCommand()
+
+        @JvmStatic
+        fun builder(node: String): NodePsCommand = NodePsCommand(node)
+
+        @JvmStatic
+        fun builder(nodes: List<String>): NodePsCommand = NodePsCommand(nodes)
+    }
+}

--- a/docker-kotlin-core/src/main/kotlin/io/github/joshrotenberg/dockerkotlin/core/command/node/NodeRmCommand.kt
+++ b/docker-kotlin-core/src/main/kotlin/io/github/joshrotenberg/dockerkotlin/core/command/node/NodeRmCommand.kt
@@ -1,0 +1,56 @@
+package io.github.joshrotenberg.dockerkotlin.core.command.node
+
+import io.github.joshrotenberg.dockerkotlin.core.CommandExecutor
+import io.github.joshrotenberg.dockerkotlin.core.command.AbstractDockerCommand
+
+/**
+ * Command to remove one or more nodes from the swarm.
+ *
+ * Equivalent to `docker node rm`.
+ *
+ * Example usage:
+ * ```kotlin
+ * NodeRmCommand("node1").executeBlocking()
+ * NodeRmCommand("node1").force().executeBlocking()
+ * NodeRmCommand(listOf("node1", "node2")).executeBlocking()
+ * ```
+ */
+class NodeRmCommand : AbstractDockerCommand<String> {
+
+    private val nodes: List<String>
+    private var force = false
+
+    constructor(node: String, executor: CommandExecutor = CommandExecutor()) : super(executor) {
+        this.nodes = listOf(node)
+    }
+
+    constructor(nodes: List<String>, executor: CommandExecutor = CommandExecutor()) : super(executor) {
+        this.nodes = nodes
+    }
+
+    /** Force remove a node from the swarm. */
+    fun force() = apply { force = true }
+
+    override fun buildArgs(): List<String> = buildList {
+        add("node")
+        add("rm")
+        if (force) add("--force")
+        addAll(nodes)
+    }
+
+    override suspend fun execute(): String {
+        return executeRaw().stdout
+    }
+
+    override fun executeBlocking(): String {
+        return executeRawBlocking().stdout
+    }
+
+    companion object {
+        @JvmStatic
+        fun builder(node: String): NodeRmCommand = NodeRmCommand(node)
+
+        @JvmStatic
+        fun builder(nodes: List<String>): NodeRmCommand = NodeRmCommand(nodes)
+    }
+}

--- a/docker-kotlin-core/src/main/kotlin/io/github/joshrotenberg/dockerkotlin/core/command/node/NodeUpdateCommand.kt
+++ b/docker-kotlin-core/src/main/kotlin/io/github/joshrotenberg/dockerkotlin/core/command/node/NodeUpdateCommand.kt
@@ -1,0 +1,62 @@
+package io.github.joshrotenberg.dockerkotlin.core.command.node
+
+import io.github.joshrotenberg.dockerkotlin.core.CommandExecutor
+import io.github.joshrotenberg.dockerkotlin.core.command.AbstractDockerCommand
+
+/**
+ * Command to update a node.
+ *
+ * Equivalent to `docker node update`.
+ *
+ * Example usage:
+ * ```kotlin
+ * NodeUpdateCommand("node1").availability("drain").executeBlocking()
+ * NodeUpdateCommand("node1").labelAdd("env", "prod").executeBlocking()
+ * NodeUpdateCommand("node1").role("manager").executeBlocking()
+ * ```
+ */
+class NodeUpdateCommand(
+    private val node: String,
+    executor: CommandExecutor = CommandExecutor()
+) : AbstractDockerCommand<String>(executor) {
+
+    private var availability: String? = null
+    private val labelAdd = mutableMapOf<String, String>()
+    private val labelRm = mutableListOf<String>()
+    private var role: String? = null
+
+    /** Node availability (active, pause, drain). */
+    fun availability(availability: String) = apply { this.availability = availability }
+
+    /** Add a node label. */
+    fun labelAdd(key: String, value: String) = apply { labelAdd[key] = value }
+
+    /** Remove a node label. */
+    fun labelRm(key: String) = apply { labelRm.add(key) }
+
+    /** Node role (worker, manager). */
+    fun role(role: String) = apply { this.role = role }
+
+    override fun buildArgs(): List<String> = buildList {
+        add("node")
+        add("update")
+        availability?.let { add("--availability"); add(it) }
+        labelAdd.forEach { (key, value) -> add("--label-add"); add("$key=$value") }
+        labelRm.forEach { add("--label-rm"); add(it) }
+        role?.let { add("--role"); add(it) }
+        add(node)
+    }
+
+    override suspend fun execute(): String {
+        return executeRaw().stdout
+    }
+
+    override fun executeBlocking(): String {
+        return executeRawBlocking().stdout
+    }
+
+    companion object {
+        @JvmStatic
+        fun builder(node: String): NodeUpdateCommand = NodeUpdateCommand(node)
+    }
+}

--- a/docker-kotlin-core/src/main/kotlin/io/github/joshrotenberg/dockerkotlin/core/command/plugin/PluginCreateCommand.kt
+++ b/docker-kotlin-core/src/main/kotlin/io/github/joshrotenberg/dockerkotlin/core/command/plugin/PluginCreateCommand.kt
@@ -1,0 +1,49 @@
+package io.github.joshrotenberg.dockerkotlin.core.command.plugin
+
+import io.github.joshrotenberg.dockerkotlin.core.CommandExecutor
+import io.github.joshrotenberg.dockerkotlin.core.command.AbstractDockerCommand
+
+/**
+ * Command to create a plugin from a rootfs and configuration.
+ *
+ * Equivalent to `docker plugin create`.
+ *
+ * Example usage:
+ * ```kotlin
+ * PluginCreateCommand("my-plugin", "/path/to/plugin").executeBlocking()
+ * PluginCreateCommand("my-plugin:1.0", "/path/to/plugin").compress().executeBlocking()
+ * ```
+ */
+class PluginCreateCommand(
+    private val plugin: String,
+    private val pluginDataDir: String,
+    executor: CommandExecutor = CommandExecutor()
+) : AbstractDockerCommand<String>(executor) {
+
+    private var compress = false
+
+    /** Compress the context using gzip. */
+    fun compress() = apply { compress = true }
+
+    override fun buildArgs(): List<String> = buildList {
+        add("plugin")
+        add("create")
+        if (compress) add("--compress")
+        add(plugin)
+        add(pluginDataDir)
+    }
+
+    override suspend fun execute(): String {
+        return executeRaw().stdout
+    }
+
+    override fun executeBlocking(): String {
+        return executeRawBlocking().stdout
+    }
+
+    companion object {
+        @JvmStatic
+        fun builder(plugin: String, pluginDataDir: String): PluginCreateCommand =
+            PluginCreateCommand(plugin, pluginDataDir)
+    }
+}

--- a/docker-kotlin-core/src/main/kotlin/io/github/joshrotenberg/dockerkotlin/core/command/plugin/PluginDisableCommand.kt
+++ b/docker-kotlin-core/src/main/kotlin/io/github/joshrotenberg/dockerkotlin/core/command/plugin/PluginDisableCommand.kt
@@ -1,0 +1,46 @@
+package io.github.joshrotenberg.dockerkotlin.core.command.plugin
+
+import io.github.joshrotenberg.dockerkotlin.core.CommandExecutor
+import io.github.joshrotenberg.dockerkotlin.core.command.AbstractDockerCommand
+
+/**
+ * Command to disable a plugin.
+ *
+ * Equivalent to `docker plugin disable`.
+ *
+ * Example usage:
+ * ```kotlin
+ * PluginDisableCommand("my-plugin").executeBlocking()
+ * PluginDisableCommand("my-plugin").force().executeBlocking()
+ * ```
+ */
+class PluginDisableCommand(
+    private val plugin: String,
+    executor: CommandExecutor = CommandExecutor()
+) : AbstractDockerCommand<String>(executor) {
+
+    private var force = false
+
+    /** Force the disable of an active plugin. */
+    fun force() = apply { force = true }
+
+    override fun buildArgs(): List<String> = buildList {
+        add("plugin")
+        add("disable")
+        if (force) add("--force")
+        add(plugin)
+    }
+
+    override suspend fun execute(): String {
+        return executeRaw().stdout
+    }
+
+    override fun executeBlocking(): String {
+        return executeRawBlocking().stdout
+    }
+
+    companion object {
+        @JvmStatic
+        fun builder(plugin: String): PluginDisableCommand = PluginDisableCommand(plugin)
+    }
+}

--- a/docker-kotlin-core/src/main/kotlin/io/github/joshrotenberg/dockerkotlin/core/command/plugin/PluginEnableCommand.kt
+++ b/docker-kotlin-core/src/main/kotlin/io/github/joshrotenberg/dockerkotlin/core/command/plugin/PluginEnableCommand.kt
@@ -1,0 +1,46 @@
+package io.github.joshrotenberg.dockerkotlin.core.command.plugin
+
+import io.github.joshrotenberg.dockerkotlin.core.CommandExecutor
+import io.github.joshrotenberg.dockerkotlin.core.command.AbstractDockerCommand
+
+/**
+ * Command to enable a plugin.
+ *
+ * Equivalent to `docker plugin enable`.
+ *
+ * Example usage:
+ * ```kotlin
+ * PluginEnableCommand("my-plugin").executeBlocking()
+ * PluginEnableCommand("my-plugin").timeout(60).executeBlocking()
+ * ```
+ */
+class PluginEnableCommand(
+    private val plugin: String,
+    executor: CommandExecutor = CommandExecutor()
+) : AbstractDockerCommand<String>(executor) {
+
+    private var timeout: Int? = null
+
+    /** HTTP client timeout (in seconds). */
+    fun timeout(seconds: Int) = apply { timeout = seconds }
+
+    override fun buildArgs(): List<String> = buildList {
+        add("plugin")
+        add("enable")
+        timeout?.let { add("--timeout"); add(it.toString()) }
+        add(plugin)
+    }
+
+    override suspend fun execute(): String {
+        return executeRaw().stdout
+    }
+
+    override fun executeBlocking(): String {
+        return executeRawBlocking().stdout
+    }
+
+    companion object {
+        @JvmStatic
+        fun builder(plugin: String): PluginEnableCommand = PluginEnableCommand(plugin)
+    }
+}

--- a/docker-kotlin-core/src/main/kotlin/io/github/joshrotenberg/dockerkotlin/core/command/plugin/PluginInspectCommand.kt
+++ b/docker-kotlin-core/src/main/kotlin/io/github/joshrotenberg/dockerkotlin/core/command/plugin/PluginInspectCommand.kt
@@ -1,0 +1,55 @@
+package io.github.joshrotenberg.dockerkotlin.core.command.plugin
+
+import io.github.joshrotenberg.dockerkotlin.core.CommandExecutor
+import io.github.joshrotenberg.dockerkotlin.core.command.AbstractDockerCommand
+
+/**
+ * Command to display detailed information on one or more plugins.
+ *
+ * Equivalent to `docker plugin inspect`.
+ *
+ * Example usage:
+ * ```kotlin
+ * PluginInspectCommand("my-plugin").executeBlocking()
+ * PluginInspectCommand("my-plugin").format("{{.Id}}").executeBlocking()
+ * ```
+ */
+class PluginInspectCommand : AbstractDockerCommand<String> {
+
+    private val plugins: List<String>
+    private var format: String? = null
+
+    constructor(plugin: String, executor: CommandExecutor = CommandExecutor()) : super(executor) {
+        this.plugins = listOf(plugin)
+    }
+
+    constructor(plugins: List<String>, executor: CommandExecutor = CommandExecutor()) : super(executor) {
+        this.plugins = plugins
+    }
+
+    /** Set output format using Go template. */
+    fun format(format: String) = apply { this.format = format }
+
+    override fun buildArgs(): List<String> = buildList {
+        add("plugin")
+        add("inspect")
+        format?.let { add("--format"); add(it) }
+        addAll(plugins)
+    }
+
+    override suspend fun execute(): String {
+        return executeRaw().stdout
+    }
+
+    override fun executeBlocking(): String {
+        return executeRawBlocking().stdout
+    }
+
+    companion object {
+        @JvmStatic
+        fun builder(plugin: String): PluginInspectCommand = PluginInspectCommand(plugin)
+
+        @JvmStatic
+        fun builder(plugins: List<String>): PluginInspectCommand = PluginInspectCommand(plugins)
+    }
+}

--- a/docker-kotlin-core/src/main/kotlin/io/github/joshrotenberg/dockerkotlin/core/command/plugin/PluginInstallCommand.kt
+++ b/docker-kotlin-core/src/main/kotlin/io/github/joshrotenberg/dockerkotlin/core/command/plugin/PluginInstallCommand.kt
@@ -1,0 +1,62 @@
+package io.github.joshrotenberg.dockerkotlin.core.command.plugin
+
+import io.github.joshrotenberg.dockerkotlin.core.CommandExecutor
+import io.github.joshrotenberg.dockerkotlin.core.command.AbstractDockerCommand
+
+/**
+ * Command to install a plugin.
+ *
+ * Equivalent to `docker plugin install`.
+ *
+ * Example usage:
+ * ```kotlin
+ * PluginInstallCommand("vieux/sshfs").executeBlocking()
+ * PluginInstallCommand("vieux/sshfs").grantAllPermissions().executeBlocking()
+ * PluginInstallCommand("vieux/sshfs").alias("sshfs").executeBlocking()
+ * ```
+ */
+class PluginInstallCommand(
+    private val plugin: String,
+    executor: CommandExecutor = CommandExecutor()
+) : AbstractDockerCommand<String>(executor) {
+
+    private var alias: String? = null
+    private var disable = false
+    private var disableContentTrust = false
+    private var grantAllPermissions = false
+
+    /** Local name for plugin. */
+    fun alias(alias: String) = apply { this.alias = alias }
+
+    /** Do not enable the plugin on install. */
+    fun disable() = apply { disable = true }
+
+    /** Skip image verification. */
+    fun disableContentTrust() = apply { disableContentTrust = true }
+
+    /** Grant all permissions necessary to run the plugin. */
+    fun grantAllPermissions() = apply { grantAllPermissions = true }
+
+    override fun buildArgs(): List<String> = buildList {
+        add("plugin")
+        add("install")
+        alias?.let { add("--alias"); add(it) }
+        if (disable) add("--disable")
+        if (disableContentTrust) add("--disable-content-trust")
+        if (grantAllPermissions) add("--grant-all-permissions")
+        add(plugin)
+    }
+
+    override suspend fun execute(): String {
+        return executeRaw().stdout
+    }
+
+    override fun executeBlocking(): String {
+        return executeRawBlocking().stdout
+    }
+
+    companion object {
+        @JvmStatic
+        fun builder(plugin: String): PluginInstallCommand = PluginInstallCommand(plugin)
+    }
+}

--- a/docker-kotlin-core/src/main/kotlin/io/github/joshrotenberg/dockerkotlin/core/command/plugin/PluginLsCommand.kt
+++ b/docker-kotlin-core/src/main/kotlin/io/github/joshrotenberg/dockerkotlin/core/command/plugin/PluginLsCommand.kt
@@ -1,0 +1,60 @@
+package io.github.joshrotenberg.dockerkotlin.core.command.plugin
+
+import io.github.joshrotenberg.dockerkotlin.core.CommandExecutor
+import io.github.joshrotenberg.dockerkotlin.core.command.AbstractDockerCommand
+
+/**
+ * Command to list plugins.
+ *
+ * Equivalent to `docker plugin ls`.
+ *
+ * Example usage:
+ * ```kotlin
+ * PluginLsCommand().executeBlocking()
+ * PluginLsCommand().filter("enabled", "true").executeBlocking()
+ * PluginLsCommand().quiet().executeBlocking()
+ * ```
+ */
+class PluginLsCommand(
+    executor: CommandExecutor = CommandExecutor()
+) : AbstractDockerCommand<String>(executor) {
+
+    private val filters = mutableMapOf<String, String>()
+    private var format: String? = null
+    private var noTrunc = false
+    private var quiet = false
+
+    /** Filter output based on conditions provided. */
+    fun filter(key: String, value: String) = apply { filters[key] = value }
+
+    /** Format output using a Go template. */
+    fun format(format: String) = apply { this.format = format }
+
+    /** Don't truncate output. */
+    fun noTrunc() = apply { noTrunc = true }
+
+    /** Only display plugin IDs. */
+    fun quiet() = apply { quiet = true }
+
+    override fun buildArgs(): List<String> = buildList {
+        add("plugin")
+        add("ls")
+        filters.forEach { (key, value) -> add("--filter"); add("$key=$value") }
+        format?.let { add("--format"); add(it) }
+        if (noTrunc) add("--no-trunc")
+        if (quiet) add("--quiet")
+    }
+
+    override suspend fun execute(): String {
+        return executeRaw().stdout
+    }
+
+    override fun executeBlocking(): String {
+        return executeRawBlocking().stdout
+    }
+
+    companion object {
+        @JvmStatic
+        fun builder(): PluginLsCommand = PluginLsCommand()
+    }
+}

--- a/docker-kotlin-core/src/main/kotlin/io/github/joshrotenberg/dockerkotlin/core/command/plugin/PluginPushCommand.kt
+++ b/docker-kotlin-core/src/main/kotlin/io/github/joshrotenberg/dockerkotlin/core/command/plugin/PluginPushCommand.kt
@@ -1,0 +1,46 @@
+package io.github.joshrotenberg.dockerkotlin.core.command.plugin
+
+import io.github.joshrotenberg.dockerkotlin.core.CommandExecutor
+import io.github.joshrotenberg.dockerkotlin.core.command.AbstractDockerCommand
+
+/**
+ * Command to push a plugin to a registry.
+ *
+ * Equivalent to `docker plugin push`.
+ *
+ * Example usage:
+ * ```kotlin
+ * PluginPushCommand("user/my-plugin").executeBlocking()
+ * PluginPushCommand("user/my-plugin").disableContentTrust().executeBlocking()
+ * ```
+ */
+class PluginPushCommand(
+    private val plugin: String,
+    executor: CommandExecutor = CommandExecutor()
+) : AbstractDockerCommand<String>(executor) {
+
+    private var disableContentTrust = false
+
+    /** Skip image signing. */
+    fun disableContentTrust() = apply { disableContentTrust = true }
+
+    override fun buildArgs(): List<String> = buildList {
+        add("plugin")
+        add("push")
+        if (disableContentTrust) add("--disable-content-trust")
+        add(plugin)
+    }
+
+    override suspend fun execute(): String {
+        return executeRaw().stdout
+    }
+
+    override fun executeBlocking(): String {
+        return executeRawBlocking().stdout
+    }
+
+    companion object {
+        @JvmStatic
+        fun builder(plugin: String): PluginPushCommand = PluginPushCommand(plugin)
+    }
+}

--- a/docker-kotlin-core/src/main/kotlin/io/github/joshrotenberg/dockerkotlin/core/command/plugin/PluginRmCommand.kt
+++ b/docker-kotlin-core/src/main/kotlin/io/github/joshrotenberg/dockerkotlin/core/command/plugin/PluginRmCommand.kt
@@ -1,0 +1,55 @@
+package io.github.joshrotenberg.dockerkotlin.core.command.plugin
+
+import io.github.joshrotenberg.dockerkotlin.core.CommandExecutor
+import io.github.joshrotenberg.dockerkotlin.core.command.AbstractDockerCommand
+
+/**
+ * Command to remove one or more plugins.
+ *
+ * Equivalent to `docker plugin rm`.
+ *
+ * Example usage:
+ * ```kotlin
+ * PluginRmCommand("my-plugin").executeBlocking()
+ * PluginRmCommand(listOf("plugin1", "plugin2")).force().executeBlocking()
+ * ```
+ */
+class PluginRmCommand : AbstractDockerCommand<String> {
+
+    private val plugins: List<String>
+    private var force = false
+
+    constructor(plugin: String, executor: CommandExecutor = CommandExecutor()) : super(executor) {
+        this.plugins = listOf(plugin)
+    }
+
+    constructor(plugins: List<String>, executor: CommandExecutor = CommandExecutor()) : super(executor) {
+        this.plugins = plugins
+    }
+
+    /** Force the removal of an active plugin. */
+    fun force() = apply { force = true }
+
+    override fun buildArgs(): List<String> = buildList {
+        add("plugin")
+        add("rm")
+        if (force) add("--force")
+        addAll(plugins)
+    }
+
+    override suspend fun execute(): String {
+        return executeRaw().stdout
+    }
+
+    override fun executeBlocking(): String {
+        return executeRawBlocking().stdout
+    }
+
+    companion object {
+        @JvmStatic
+        fun builder(plugin: String): PluginRmCommand = PluginRmCommand(plugin)
+
+        @JvmStatic
+        fun builder(plugins: List<String>): PluginRmCommand = PluginRmCommand(plugins)
+    }
+}

--- a/docker-kotlin-core/src/main/kotlin/io/github/joshrotenberg/dockerkotlin/core/command/plugin/PluginSetCommand.kt
+++ b/docker-kotlin-core/src/main/kotlin/io/github/joshrotenberg/dockerkotlin/core/command/plugin/PluginSetCommand.kt
@@ -1,0 +1,47 @@
+package io.github.joshrotenberg.dockerkotlin.core.command.plugin
+
+import io.github.joshrotenberg.dockerkotlin.core.CommandExecutor
+import io.github.joshrotenberg.dockerkotlin.core.command.AbstractDockerCommand
+
+/**
+ * Command to change settings for a plugin.
+ *
+ * Equivalent to `docker plugin set`.
+ *
+ * Example usage:
+ * ```kotlin
+ * PluginSetCommand("my-plugin", listOf("DEBUG=1")).executeBlocking()
+ * PluginSetCommand("my-plugin", listOf("myvar=value", "another=val2")).executeBlocking()
+ * ```
+ */
+class PluginSetCommand(
+    private val plugin: String,
+    private val settings: List<String>,
+    executor: CommandExecutor = CommandExecutor()
+) : AbstractDockerCommand<String>(executor) {
+
+    override fun buildArgs(): List<String> = buildList {
+        add("plugin")
+        add("set")
+        add(plugin)
+        addAll(settings)
+    }
+
+    override suspend fun execute(): String {
+        return executeRaw().stdout
+    }
+
+    override fun executeBlocking(): String {
+        return executeRawBlocking().stdout
+    }
+
+    companion object {
+        @JvmStatic
+        fun builder(plugin: String, settings: List<String>): PluginSetCommand =
+            PluginSetCommand(plugin, settings)
+
+        @JvmStatic
+        fun builder(plugin: String, vararg settings: String): PluginSetCommand =
+            PluginSetCommand(plugin, settings.toList())
+    }
+}

--- a/docker-kotlin-core/src/main/kotlin/io/github/joshrotenberg/dockerkotlin/core/command/plugin/PluginUpgradeCommand.kt
+++ b/docker-kotlin-core/src/main/kotlin/io/github/joshrotenberg/dockerkotlin/core/command/plugin/PluginUpgradeCommand.kt
@@ -1,0 +1,59 @@
+package io.github.joshrotenberg.dockerkotlin.core.command.plugin
+
+import io.github.joshrotenberg.dockerkotlin.core.CommandExecutor
+import io.github.joshrotenberg.dockerkotlin.core.command.AbstractDockerCommand
+
+/**
+ * Command to upgrade an existing plugin.
+ *
+ * Equivalent to `docker plugin upgrade`.
+ *
+ * Example usage:
+ * ```kotlin
+ * PluginUpgradeCommand("my-plugin", "user/my-plugin:latest").executeBlocking()
+ * PluginUpgradeCommand("my-plugin", "user/my-plugin:v2").grantAllPermissions().executeBlocking()
+ * ```
+ */
+class PluginUpgradeCommand(
+    private val plugin: String,
+    private val remote: String,
+    executor: CommandExecutor = CommandExecutor()
+) : AbstractDockerCommand<String>(executor) {
+
+    private var disableContentTrust = false
+    private var grantAllPermissions = false
+    private var skipRemoteCheck = false
+
+    /** Skip image verification. */
+    fun disableContentTrust() = apply { disableContentTrust = true }
+
+    /** Grant all permissions necessary to run the plugin. */
+    fun grantAllPermissions() = apply { grantAllPermissions = true }
+
+    /** Do not check if specified remote plugin matches existing plugin image. */
+    fun skipRemoteCheck() = apply { skipRemoteCheck = true }
+
+    override fun buildArgs(): List<String> = buildList {
+        add("plugin")
+        add("upgrade")
+        if (disableContentTrust) add("--disable-content-trust")
+        if (grantAllPermissions) add("--grant-all-permissions")
+        if (skipRemoteCheck) add("--skip-remote-check")
+        add(plugin)
+        add(remote)
+    }
+
+    override suspend fun execute(): String {
+        return executeRaw().stdout
+    }
+
+    override fun executeBlocking(): String {
+        return executeRawBlocking().stdout
+    }
+
+    companion object {
+        @JvmStatic
+        fun builder(plugin: String, remote: String): PluginUpgradeCommand =
+            PluginUpgradeCommand(plugin, remote)
+    }
+}

--- a/docker-kotlin-core/src/main/kotlin/io/github/joshrotenberg/dockerkotlin/core/command/secret/SecretCreateCommand.kt
+++ b/docker-kotlin-core/src/main/kotlin/io/github/joshrotenberg/dockerkotlin/core/command/secret/SecretCreateCommand.kt
@@ -1,0 +1,62 @@
+package io.github.joshrotenberg.dockerkotlin.core.command.secret
+
+import io.github.joshrotenberg.dockerkotlin.core.CommandExecutor
+import io.github.joshrotenberg.dockerkotlin.core.command.AbstractDockerCommand
+
+/**
+ * Command to create a secret from a file or STDIN.
+ *
+ * Equivalent to `docker secret create`.
+ *
+ * Example usage:
+ * ```kotlin
+ * SecretCreateCommand("my-secret", "/path/to/secret.txt").executeBlocking()
+ * SecretCreateCommand("my-secret", "-").label("env", "prod").executeBlocking()
+ * ```
+ */
+class SecretCreateCommand(
+    private val name: String,
+    private val file: String,
+    executor: CommandExecutor = CommandExecutor()
+) : AbstractDockerCommand<String>(executor) {
+
+    private val labels = mutableMapOf<String, String>()
+    private var driver: String? = null
+    private var templateDriver: String? = null
+
+    /** Add a label to the secret. */
+    fun label(key: String, value: String) = apply { labels[key] = value }
+
+    /** Add multiple labels to the secret. */
+    fun labels(labels: Map<String, String>) = apply { this.labels.putAll(labels) }
+
+    /** Secret driver. */
+    fun driver(driver: String) = apply { this.driver = driver }
+
+    /** Template driver. */
+    fun templateDriver(driver: String) = apply { templateDriver = driver }
+
+    override fun buildArgs(): List<String> = buildList {
+        add("secret")
+        add("create")
+        driver?.let { add("--driver"); add(it) }
+        labels.forEach { (key, value) -> add("--label"); add("$key=$value") }
+        templateDriver?.let { add("--template-driver"); add(it) }
+        add(name)
+        add(file)
+    }
+
+    override suspend fun execute(): String {
+        return executeRaw().stdout.trim()
+    }
+
+    override fun executeBlocking(): String {
+        return executeRawBlocking().stdout.trim()
+    }
+
+    companion object {
+        @JvmStatic
+        fun builder(name: String, file: String): SecretCreateCommand =
+            SecretCreateCommand(name, file)
+    }
+}

--- a/docker-kotlin-core/src/main/kotlin/io/github/joshrotenberg/dockerkotlin/core/command/secret/SecretInspectCommand.kt
+++ b/docker-kotlin-core/src/main/kotlin/io/github/joshrotenberg/dockerkotlin/core/command/secret/SecretInspectCommand.kt
@@ -1,0 +1,61 @@
+package io.github.joshrotenberg.dockerkotlin.core.command.secret
+
+import io.github.joshrotenberg.dockerkotlin.core.CommandExecutor
+import io.github.joshrotenberg.dockerkotlin.core.command.AbstractDockerCommand
+
+/**
+ * Command to display detailed information on one or more secrets.
+ *
+ * Equivalent to `docker secret inspect`.
+ *
+ * Example usage:
+ * ```kotlin
+ * SecretInspectCommand("my-secret").executeBlocking()
+ * SecretInspectCommand("my-secret").format("{{.ID}}").executeBlocking()
+ * SecretInspectCommand(listOf("secret1", "secret2")).executeBlocking()
+ * ```
+ */
+class SecretInspectCommand : AbstractDockerCommand<String> {
+
+    private val secrets: List<String>
+    private var format: String? = null
+    private var pretty = false
+
+    constructor(secret: String, executor: CommandExecutor = CommandExecutor()) : super(executor) {
+        this.secrets = listOf(secret)
+    }
+
+    constructor(secrets: List<String>, executor: CommandExecutor = CommandExecutor()) : super(executor) {
+        this.secrets = secrets
+    }
+
+    /** Format output using a Go template. */
+    fun format(format: String) = apply { this.format = format }
+
+    /** Print the information in a human friendly format. */
+    fun pretty() = apply { pretty = true }
+
+    override fun buildArgs(): List<String> = buildList {
+        add("secret")
+        add("inspect")
+        format?.let { add("--format"); add(it) }
+        if (pretty) add("--pretty")
+        addAll(secrets)
+    }
+
+    override suspend fun execute(): String {
+        return executeRaw().stdout
+    }
+
+    override fun executeBlocking(): String {
+        return executeRawBlocking().stdout
+    }
+
+    companion object {
+        @JvmStatic
+        fun builder(secret: String): SecretInspectCommand = SecretInspectCommand(secret)
+
+        @JvmStatic
+        fun builder(secrets: List<String>): SecretInspectCommand = SecretInspectCommand(secrets)
+    }
+}

--- a/docker-kotlin-core/src/main/kotlin/io/github/joshrotenberg/dockerkotlin/core/command/secret/SecretLsCommand.kt
+++ b/docker-kotlin-core/src/main/kotlin/io/github/joshrotenberg/dockerkotlin/core/command/secret/SecretLsCommand.kt
@@ -1,0 +1,55 @@
+package io.github.joshrotenberg.dockerkotlin.core.command.secret
+
+import io.github.joshrotenberg.dockerkotlin.core.CommandExecutor
+import io.github.joshrotenberg.dockerkotlin.core.command.AbstractDockerCommand
+
+/**
+ * Command to list secrets.
+ *
+ * Equivalent to `docker secret ls`.
+ *
+ * Example usage:
+ * ```kotlin
+ * SecretLsCommand().executeBlocking()
+ * SecretLsCommand().filter("name", "my-secret").executeBlocking()
+ * SecretLsCommand().quiet().executeBlocking()
+ * ```
+ */
+class SecretLsCommand(
+    executor: CommandExecutor = CommandExecutor()
+) : AbstractDockerCommand<String>(executor) {
+
+    private val filters = mutableMapOf<String, String>()
+    private var format: String? = null
+    private var quiet = false
+
+    /** Filter output based on conditions provided. */
+    fun filter(key: String, value: String) = apply { filters[key] = value }
+
+    /** Format output using a Go template. */
+    fun format(format: String) = apply { this.format = format }
+
+    /** Only display secret IDs. */
+    fun quiet() = apply { quiet = true }
+
+    override fun buildArgs(): List<String> = buildList {
+        add("secret")
+        add("ls")
+        filters.forEach { (key, value) -> add("--filter"); add("$key=$value") }
+        format?.let { add("--format"); add(it) }
+        if (quiet) add("--quiet")
+    }
+
+    override suspend fun execute(): String {
+        return executeRaw().stdout
+    }
+
+    override fun executeBlocking(): String {
+        return executeRawBlocking().stdout
+    }
+
+    companion object {
+        @JvmStatic
+        fun builder(): SecretLsCommand = SecretLsCommand()
+    }
+}

--- a/docker-kotlin-core/src/main/kotlin/io/github/joshrotenberg/dockerkotlin/core/command/secret/SecretRmCommand.kt
+++ b/docker-kotlin-core/src/main/kotlin/io/github/joshrotenberg/dockerkotlin/core/command/secret/SecretRmCommand.kt
@@ -1,0 +1,50 @@
+package io.github.joshrotenberg.dockerkotlin.core.command.secret
+
+import io.github.joshrotenberg.dockerkotlin.core.CommandExecutor
+import io.github.joshrotenberg.dockerkotlin.core.command.AbstractDockerCommand
+
+/**
+ * Command to remove one or more secrets.
+ *
+ * Equivalent to `docker secret rm`.
+ *
+ * Example usage:
+ * ```kotlin
+ * SecretRmCommand("my-secret").executeBlocking()
+ * SecretRmCommand(listOf("secret1", "secret2")).executeBlocking()
+ * ```
+ */
+class SecretRmCommand : AbstractDockerCommand<String> {
+
+    private val secrets: List<String>
+
+    constructor(secret: String, executor: CommandExecutor = CommandExecutor()) : super(executor) {
+        this.secrets = listOf(secret)
+    }
+
+    constructor(secrets: List<String>, executor: CommandExecutor = CommandExecutor()) : super(executor) {
+        this.secrets = secrets
+    }
+
+    override fun buildArgs(): List<String> = buildList {
+        add("secret")
+        add("rm")
+        addAll(secrets)
+    }
+
+    override suspend fun execute(): String {
+        return executeRaw().stdout
+    }
+
+    override fun executeBlocking(): String {
+        return executeRawBlocking().stdout
+    }
+
+    companion object {
+        @JvmStatic
+        fun builder(secret: String): SecretRmCommand = SecretRmCommand(secret)
+
+        @JvmStatic
+        fun builder(secrets: List<String>): SecretRmCommand = SecretRmCommand(secrets)
+    }
+}

--- a/docker-kotlin-core/src/main/kotlin/io/github/joshrotenberg/dockerkotlin/core/command/service/ServiceCreateCommand.kt
+++ b/docker-kotlin-core/src/main/kotlin/io/github/joshrotenberg/dockerkotlin/core/command/service/ServiceCreateCommand.kt
@@ -1,0 +1,290 @@
+package io.github.joshrotenberg.dockerkotlin.core.command.service
+
+import io.github.joshrotenberg.dockerkotlin.core.CommandExecutor
+import io.github.joshrotenberg.dockerkotlin.core.command.AbstractDockerCommand
+
+/**
+ * Command to create a new service.
+ *
+ * Equivalent to `docker service create`.
+ *
+ * Example usage:
+ * ```kotlin
+ * ServiceCreateCommand("nginx:latest")
+ *     .name("my-nginx")
+ *     .replicas(3)
+ *     .port(80, 80)
+ *     .executeBlocking()
+ * ```
+ */
+class ServiceCreateCommand(
+    private val image: String,
+    executor: CommandExecutor = CommandExecutor()
+) : AbstractDockerCommand<String>(executor) {
+
+    private var name: String? = null
+    private var replicas: Int? = null
+    private var mode: String? = null
+    private val envVars = mutableMapOf<String, String>()
+    private val labels = mutableMapOf<String, String>()
+    private val containerLabels = mutableMapOf<String, String>()
+    private val ports = mutableListOf<String>()
+    private val mounts = mutableListOf<String>()
+    private val networks = mutableListOf<String>()
+    private val constraints = mutableListOf<String>()
+    private val secrets = mutableListOf<String>()
+    private val configs = mutableListOf<String>()
+    private var workdir: String? = null
+    private var user: String? = null
+    private var entrypoint: String? = null
+    private val command = mutableListOf<String>()
+    private var restartCondition: String? = null
+    private var restartDelay: String? = null
+    private var restartMaxAttempts: Int? = null
+    private var restartWindow: String? = null
+    private var updateDelay: String? = null
+    private var updateParallelism: Int? = null
+    private var updateFailureAction: String? = null
+    private var updateOrder: String? = null
+    private var rollbackDelay: String? = null
+    private var rollbackParallelism: Int? = null
+    private var rollbackFailureAction: String? = null
+    private var rollbackOrder: String? = null
+    private var limitCpu: String? = null
+    private var limitMemory: String? = null
+    private var reserveCpu: String? = null
+    private var reserveMemory: String? = null
+    private var endpointMode: String? = null
+    private var hostname: String? = null
+    private var healthCmd: String? = null
+    private var healthInterval: String? = null
+    private var healthRetries: Int? = null
+    private var healthTimeout: String? = null
+    private var healthStartPeriod: String? = null
+    private var noHealthcheck = false
+    private var readOnly = false
+    private var tty = false
+    private var detach = true
+
+    /** Set service name. */
+    fun name(name: String) = apply { this.name = name }
+
+    /** Number of tasks (replicas). */
+    fun replicas(replicas: Int) = apply { this.replicas = replicas }
+
+    /** Service mode (replicated or global). */
+    fun mode(mode: String) = apply { this.mode = mode }
+
+    /** Set an environment variable. */
+    fun env(key: String, value: String) = apply { envVars[key] = value }
+
+    /** Set multiple environment variables. */
+    fun env(vars: Map<String, String>) = apply { envVars.putAll(vars) }
+
+    /** Add a service label. */
+    fun label(key: String, value: String) = apply { labels[key] = value }
+
+    /** Add a container label. */
+    fun containerLabel(key: String, value: String) = apply { containerLabels[key] = value }
+
+    /** Publish a port. */
+    fun port(published: Int, target: Int, protocol: String = "tcp") = apply {
+        ports.add("published=$published,target=$target,protocol=$protocol")
+    }
+
+    /** Publish a port with full spec. */
+    fun port(spec: String) = apply { ports.add(spec) }
+
+    /** Add a mount. */
+    fun mount(spec: String) = apply { mounts.add(spec) }
+
+    /** Add a bind mount. */
+    fun mount(source: String, target: String, readOnly: Boolean = false) = apply {
+        val ro = if (readOnly) ",readonly" else ""
+        mounts.add("type=bind,source=$source,target=$target$ro")
+    }
+
+    /** Add a volume mount. */
+    fun volume(source: String, target: String) = apply {
+        mounts.add("type=volume,source=$source,target=$target")
+    }
+
+    /** Attach to a network. */
+    fun network(network: String) = apply { networks.add(network) }
+
+    /** Add a placement constraint. */
+    fun constraint(constraint: String) = apply { constraints.add(constraint) }
+
+    /** Add a secret. */
+    fun secret(secret: String) = apply { secrets.add(secret) }
+
+    /** Add a config. */
+    fun config(config: String) = apply { configs.add(config) }
+
+    /** Set working directory. */
+    fun workdir(workdir: String) = apply { this.workdir = workdir }
+
+    /** Set user. */
+    fun user(user: String) = apply { this.user = user }
+
+    /** Set entrypoint. */
+    fun entrypoint(entrypoint: String) = apply { this.entrypoint = entrypoint }
+
+    /** Set command to run. */
+    fun command(vararg args: String) = apply { command.addAll(args) }
+
+    /** Set restart condition (none, on-failure, any). */
+    fun restartCondition(condition: String) = apply { restartCondition = condition }
+
+    /** Set delay between restart attempts. */
+    fun restartDelay(delay: String) = apply { restartDelay = delay }
+
+    /** Set maximum number of restart attempts. */
+    fun restartMaxAttempts(attempts: Int) = apply { restartMaxAttempts = attempts }
+
+    /** Set window for restart policy evaluation. */
+    fun restartWindow(window: String) = apply { restartWindow = window }
+
+    /** Delay between updates. */
+    fun updateDelay(delay: String) = apply { updateDelay = delay }
+
+    /** Maximum number of tasks updated simultaneously. */
+    fun updateParallelism(parallelism: Int) = apply { updateParallelism = parallelism }
+
+    /** Action on update failure (pause, continue, rollback). */
+    fun updateFailureAction(action: String) = apply { updateFailureAction = action }
+
+    /** Update order (start-first, stop-first). */
+    fun updateOrder(order: String) = apply { updateOrder = order }
+
+    /** Delay between rollback attempts. */
+    fun rollbackDelay(delay: String) = apply { rollbackDelay = delay }
+
+    /** Maximum number of tasks rolled back simultaneously. */
+    fun rollbackParallelism(parallelism: Int) = apply { rollbackParallelism = parallelism }
+
+    /** Action on rollback failure. */
+    fun rollbackFailureAction(action: String) = apply { rollbackFailureAction = action }
+
+    /** Rollback order. */
+    fun rollbackOrder(order: String) = apply { rollbackOrder = order }
+
+    /** Limit CPUs. */
+    fun limitCpu(cpu: String) = apply { limitCpu = cpu }
+
+    /** Limit memory. */
+    fun limitMemory(memory: String) = apply { limitMemory = memory }
+
+    /** Reserve CPUs. */
+    fun reserveCpu(cpu: String) = apply { reserveCpu = cpu }
+
+    /** Reserve memory. */
+    fun reserveMemory(memory: String) = apply { reserveMemory = memory }
+
+    /** Endpoint mode (vip or dnsrr). */
+    fun endpointMode(mode: String) = apply { endpointMode = mode }
+
+    /** Container hostname. */
+    fun hostname(hostname: String) = apply { this.hostname = hostname }
+
+    /** Health check command. */
+    fun healthCmd(cmd: String) = apply { healthCmd = cmd }
+
+    /** Health check interval. */
+    fun healthInterval(interval: String) = apply { healthInterval = interval }
+
+    /** Health check retries. */
+    fun healthRetries(retries: Int) = apply { healthRetries = retries }
+
+    /** Health check timeout. */
+    fun healthTimeout(timeout: String) = apply { healthTimeout = timeout }
+
+    /** Health check start period. */
+    fun healthStartPeriod(period: String) = apply { healthStartPeriod = period }
+
+    /** Disable health check. */
+    fun noHealthcheck() = apply { noHealthcheck = true }
+
+    /** Mount root filesystem as read only. */
+    fun readOnly() = apply { readOnly = true }
+
+    /** Allocate a pseudo-TTY. */
+    fun tty() = apply { tty = true }
+
+    /** Run in foreground (don't detach). */
+    fun noDetach() = apply { detach = false }
+
+    override fun buildArgs(): List<String> = buildList {
+        add("service")
+        add("create")
+
+        name?.let { add("--name"); add(it) }
+        replicas?.let { add("--replicas"); add(it.toString()) }
+        mode?.let { add("--mode"); add(it) }
+
+        envVars.forEach { (key, value) -> add("--env"); add("$key=$value") }
+        labels.forEach { (key, value) -> add("--label"); add("$key=$value") }
+        containerLabels.forEach { (key, value) -> add("--container-label"); add("$key=$value") }
+
+        ports.forEach { add("--publish"); add(it) }
+        mounts.forEach { add("--mount"); add(it) }
+        networks.forEach { add("--network"); add(it) }
+        constraints.forEach { add("--constraint"); add(it) }
+        secrets.forEach { add("--secret"); add(it) }
+        configs.forEach { add("--config"); add(it) }
+
+        workdir?.let { add("--workdir"); add(it) }
+        user?.let { add("--user"); add(it) }
+        entrypoint?.let { add("--entrypoint"); add(it) }
+
+        restartCondition?.let { add("--restart-condition"); add(it) }
+        restartDelay?.let { add("--restart-delay"); add(it) }
+        restartMaxAttempts?.let { add("--restart-max-attempts"); add(it.toString()) }
+        restartWindow?.let { add("--restart-window"); add(it) }
+
+        updateDelay?.let { add("--update-delay"); add(it) }
+        updateParallelism?.let { add("--update-parallelism"); add(it.toString()) }
+        updateFailureAction?.let { add("--update-failure-action"); add(it) }
+        updateOrder?.let { add("--update-order"); add(it) }
+
+        rollbackDelay?.let { add("--rollback-delay"); add(it) }
+        rollbackParallelism?.let { add("--rollback-parallelism"); add(it.toString()) }
+        rollbackFailureAction?.let { add("--rollback-failure-action"); add(it) }
+        rollbackOrder?.let { add("--rollback-order"); add(it) }
+
+        limitCpu?.let { add("--limit-cpu"); add(it) }
+        limitMemory?.let { add("--limit-memory"); add(it) }
+        reserveCpu?.let { add("--reserve-cpu"); add(it) }
+        reserveMemory?.let { add("--reserve-memory"); add(it) }
+
+        endpointMode?.let { add("--endpoint-mode"); add(it) }
+        hostname?.let { add("--hostname"); add(it) }
+
+        healthCmd?.let { add("--health-cmd"); add(it) }
+        healthInterval?.let { add("--health-interval"); add(it) }
+        healthRetries?.let { add("--health-retries"); add(it.toString()) }
+        healthTimeout?.let { add("--health-timeout"); add(it) }
+        healthStartPeriod?.let { add("--health-start-period"); add(it) }
+
+        if (noHealthcheck) add("--no-healthcheck")
+        if (readOnly) add("--read-only")
+        if (tty) add("--tty")
+        if (detach) add("--detach")
+
+        add(image)
+        addAll(command)
+    }
+
+    override suspend fun execute(): String {
+        return executeRaw().stdout.trim()
+    }
+
+    override fun executeBlocking(): String {
+        return executeRawBlocking().stdout.trim()
+    }
+
+    companion object {
+        @JvmStatic
+        fun builder(image: String): ServiceCreateCommand = ServiceCreateCommand(image)
+    }
+}

--- a/docker-kotlin-core/src/main/kotlin/io/github/joshrotenberg/dockerkotlin/core/command/service/ServiceInspectCommand.kt
+++ b/docker-kotlin-core/src/main/kotlin/io/github/joshrotenberg/dockerkotlin/core/command/service/ServiceInspectCommand.kt
@@ -1,0 +1,61 @@
+package io.github.joshrotenberg.dockerkotlin.core.command.service
+
+import io.github.joshrotenberg.dockerkotlin.core.CommandExecutor
+import io.github.joshrotenberg.dockerkotlin.core.command.AbstractDockerCommand
+
+/**
+ * Command to display detailed information on one or more services.
+ *
+ * Equivalent to `docker service inspect`.
+ *
+ * Example usage:
+ * ```kotlin
+ * ServiceInspectCommand("my-service").executeBlocking()
+ * ServiceInspectCommand("my-service").pretty().executeBlocking()
+ * ServiceInspectCommand("my-service").format("{{.ID}}").executeBlocking()
+ * ```
+ */
+class ServiceInspectCommand : AbstractDockerCommand<String> {
+
+    private val services: List<String>
+    private var format: String? = null
+    private var pretty = false
+
+    constructor(service: String, executor: CommandExecutor = CommandExecutor()) : super(executor) {
+        this.services = listOf(service)
+    }
+
+    constructor(services: List<String>, executor: CommandExecutor = CommandExecutor()) : super(executor) {
+        this.services = services
+    }
+
+    /** Format output using a Go template. */
+    fun format(format: String) = apply { this.format = format }
+
+    /** Print the information in a human friendly format. */
+    fun pretty() = apply { pretty = true }
+
+    override fun buildArgs(): List<String> = buildList {
+        add("service")
+        add("inspect")
+        format?.let { add("--format"); add(it) }
+        if (pretty) add("--pretty")
+        addAll(services)
+    }
+
+    override suspend fun execute(): String {
+        return executeRaw().stdout
+    }
+
+    override fun executeBlocking(): String {
+        return executeRawBlocking().stdout
+    }
+
+    companion object {
+        @JvmStatic
+        fun builder(service: String): ServiceInspectCommand = ServiceInspectCommand(service)
+
+        @JvmStatic
+        fun builder(services: List<String>): ServiceInspectCommand = ServiceInspectCommand(services)
+    }
+}

--- a/docker-kotlin-core/src/main/kotlin/io/github/joshrotenberg/dockerkotlin/core/command/service/ServiceLogsCommand.kt
+++ b/docker-kotlin-core/src/main/kotlin/io/github/joshrotenberg/dockerkotlin/core/command/service/ServiceLogsCommand.kt
@@ -1,0 +1,90 @@
+package io.github.joshrotenberg.dockerkotlin.core.command.service
+
+import io.github.joshrotenberg.dockerkotlin.core.CommandExecutor
+import io.github.joshrotenberg.dockerkotlin.core.command.AbstractDockerCommand
+
+/**
+ * Command to fetch the logs of a service or task.
+ *
+ * Equivalent to `docker service logs`.
+ *
+ * Example usage:
+ * ```kotlin
+ * ServiceLogsCommand("my-service").executeBlocking()
+ * ServiceLogsCommand("my-service").tail(100).timestamps().executeBlocking()
+ * ServiceLogsCommand("my-service").follow().executeBlocking()
+ * ```
+ */
+class ServiceLogsCommand(
+    private val service: String,
+    executor: CommandExecutor = CommandExecutor()
+) : AbstractDockerCommand<String>(executor) {
+
+    private var details = false
+    private var follow = false
+    private var noResolve = false
+    private var noTaskIds = false
+    private var noTrunc = false
+    private var raw = false
+    private var since: String? = null
+    private var tail: String? = null
+    private var timestamps = false
+
+    /** Show extra details provided to logs. */
+    fun details() = apply { details = true }
+
+    /** Follow log output. */
+    fun follow() = apply { follow = true }
+
+    /** Do not map IDs to names. */
+    fun noResolve() = apply { noResolve = true }
+
+    /** Do not include task IDs. */
+    fun noTaskIds() = apply { noTaskIds = true }
+
+    /** Do not truncate output. */
+    fun noTrunc() = apply { noTrunc = true }
+
+    /** Do not neatly format logs. */
+    fun raw() = apply { raw = true }
+
+    /** Show logs since timestamp or relative (e.g. 42m for 42 minutes). */
+    fun since(since: String) = apply { this.since = since }
+
+    /** Number of lines to show from the end of the logs. */
+    fun tail(lines: Int) = apply { tail = lines.toString() }
+
+    /** Show all logs (don't tail). */
+    fun tailAll() = apply { tail = "all" }
+
+    /** Show timestamps. */
+    fun timestamps() = apply { timestamps = true }
+
+    override fun buildArgs(): List<String> = buildList {
+        add("service")
+        add("logs")
+        if (details) add("--details")
+        if (follow) add("--follow")
+        if (noResolve) add("--no-resolve")
+        if (noTaskIds) add("--no-task-ids")
+        if (noTrunc) add("--no-trunc")
+        if (raw) add("--raw")
+        since?.let { add("--since"); add(it) }
+        tail?.let { add("--tail"); add(it) }
+        if (timestamps) add("--timestamps")
+        add(service)
+    }
+
+    override suspend fun execute(): String {
+        return executeRaw().stdout
+    }
+
+    override fun executeBlocking(): String {
+        return executeRawBlocking().stdout
+    }
+
+    companion object {
+        @JvmStatic
+        fun builder(service: String): ServiceLogsCommand = ServiceLogsCommand(service)
+    }
+}

--- a/docker-kotlin-core/src/main/kotlin/io/github/joshrotenberg/dockerkotlin/core/command/service/ServiceLsCommand.kt
+++ b/docker-kotlin-core/src/main/kotlin/io/github/joshrotenberg/dockerkotlin/core/command/service/ServiceLsCommand.kt
@@ -1,0 +1,55 @@
+package io.github.joshrotenberg.dockerkotlin.core.command.service
+
+import io.github.joshrotenberg.dockerkotlin.core.CommandExecutor
+import io.github.joshrotenberg.dockerkotlin.core.command.AbstractDockerCommand
+
+/**
+ * Command to list services.
+ *
+ * Equivalent to `docker service ls`.
+ *
+ * Example usage:
+ * ```kotlin
+ * ServiceLsCommand().executeBlocking()
+ * ServiceLsCommand().filter("name", "my-service").executeBlocking()
+ * ServiceLsCommand().quiet().executeBlocking()
+ * ```
+ */
+class ServiceLsCommand(
+    executor: CommandExecutor = CommandExecutor()
+) : AbstractDockerCommand<String>(executor) {
+
+    private val filters = mutableMapOf<String, String>()
+    private var format: String? = null
+    private var quiet = false
+
+    /** Filter output based on conditions provided. */
+    fun filter(key: String, value: String) = apply { filters[key] = value }
+
+    /** Format output using a Go template. */
+    fun format(format: String) = apply { this.format = format }
+
+    /** Only display service IDs. */
+    fun quiet() = apply { quiet = true }
+
+    override fun buildArgs(): List<String> = buildList {
+        add("service")
+        add("ls")
+        filters.forEach { (key, value) -> add("--filter"); add("$key=$value") }
+        format?.let { add("--format"); add(it) }
+        if (quiet) add("--quiet")
+    }
+
+    override suspend fun execute(): String {
+        return executeRaw().stdout
+    }
+
+    override fun executeBlocking(): String {
+        return executeRawBlocking().stdout
+    }
+
+    companion object {
+        @JvmStatic
+        fun builder(): ServiceLsCommand = ServiceLsCommand()
+    }
+}

--- a/docker-kotlin-core/src/main/kotlin/io/github/joshrotenberg/dockerkotlin/core/command/service/ServicePsCommand.kt
+++ b/docker-kotlin-core/src/main/kotlin/io/github/joshrotenberg/dockerkotlin/core/command/service/ServicePsCommand.kt
@@ -1,0 +1,76 @@
+package io.github.joshrotenberg.dockerkotlin.core.command.service
+
+import io.github.joshrotenberg.dockerkotlin.core.CommandExecutor
+import io.github.joshrotenberg.dockerkotlin.core.command.AbstractDockerCommand
+
+/**
+ * Command to list the tasks of one or more services.
+ *
+ * Equivalent to `docker service ps`.
+ *
+ * Example usage:
+ * ```kotlin
+ * ServicePsCommand("my-service").executeBlocking()
+ * ServicePsCommand("my-service").filter("desired-state", "running").executeBlocking()
+ * ServicePsCommand(listOf("service1", "service2")).noTrunc().executeBlocking()
+ * ```
+ */
+class ServicePsCommand : AbstractDockerCommand<String> {
+
+    private val services: List<String>
+    private val filters = mutableMapOf<String, String>()
+    private var format: String? = null
+    private var noResolve = false
+    private var noTrunc = false
+    private var quiet = false
+
+    constructor(service: String, executor: CommandExecutor = CommandExecutor()) : super(executor) {
+        this.services = listOf(service)
+    }
+
+    constructor(services: List<String>, executor: CommandExecutor = CommandExecutor()) : super(executor) {
+        this.services = services
+    }
+
+    /** Filter output based on conditions provided. */
+    fun filter(key: String, value: String) = apply { filters[key] = value }
+
+    /** Format output using a Go template. */
+    fun format(format: String) = apply { this.format = format }
+
+    /** Do not map IDs to names. */
+    fun noResolve() = apply { noResolve = true }
+
+    /** Do not truncate output. */
+    fun noTrunc() = apply { noTrunc = true }
+
+    /** Only display task IDs. */
+    fun quiet() = apply { quiet = true }
+
+    override fun buildArgs(): List<String> = buildList {
+        add("service")
+        add("ps")
+        filters.forEach { (key, value) -> add("--filter"); add("$key=$value") }
+        format?.let { add("--format"); add(it) }
+        if (noResolve) add("--no-resolve")
+        if (noTrunc) add("--no-trunc")
+        if (quiet) add("--quiet")
+        addAll(services)
+    }
+
+    override suspend fun execute(): String {
+        return executeRaw().stdout
+    }
+
+    override fun executeBlocking(): String {
+        return executeRawBlocking().stdout
+    }
+
+    companion object {
+        @JvmStatic
+        fun builder(service: String): ServicePsCommand = ServicePsCommand(service)
+
+        @JvmStatic
+        fun builder(services: List<String>): ServicePsCommand = ServicePsCommand(services)
+    }
+}

--- a/docker-kotlin-core/src/main/kotlin/io/github/joshrotenberg/dockerkotlin/core/command/service/ServiceRmCommand.kt
+++ b/docker-kotlin-core/src/main/kotlin/io/github/joshrotenberg/dockerkotlin/core/command/service/ServiceRmCommand.kt
@@ -1,0 +1,50 @@
+package io.github.joshrotenberg.dockerkotlin.core.command.service
+
+import io.github.joshrotenberg.dockerkotlin.core.CommandExecutor
+import io.github.joshrotenberg.dockerkotlin.core.command.AbstractDockerCommand
+
+/**
+ * Command to remove one or more services.
+ *
+ * Equivalent to `docker service rm`.
+ *
+ * Example usage:
+ * ```kotlin
+ * ServiceRmCommand("my-service").executeBlocking()
+ * ServiceRmCommand(listOf("service1", "service2")).executeBlocking()
+ * ```
+ */
+class ServiceRmCommand : AbstractDockerCommand<String> {
+
+    private val services: List<String>
+
+    constructor(service: String, executor: CommandExecutor = CommandExecutor()) : super(executor) {
+        this.services = listOf(service)
+    }
+
+    constructor(services: List<String>, executor: CommandExecutor = CommandExecutor()) : super(executor) {
+        this.services = services
+    }
+
+    override fun buildArgs(): List<String> = buildList {
+        add("service")
+        add("rm")
+        addAll(services)
+    }
+
+    override suspend fun execute(): String {
+        return executeRaw().stdout
+    }
+
+    override fun executeBlocking(): String {
+        return executeRawBlocking().stdout
+    }
+
+    companion object {
+        @JvmStatic
+        fun builder(service: String): ServiceRmCommand = ServiceRmCommand(service)
+
+        @JvmStatic
+        fun builder(services: List<String>): ServiceRmCommand = ServiceRmCommand(services)
+    }
+}

--- a/docker-kotlin-core/src/main/kotlin/io/github/joshrotenberg/dockerkotlin/core/command/service/ServiceRollbackCommand.kt
+++ b/docker-kotlin-core/src/main/kotlin/io/github/joshrotenberg/dockerkotlin/core/command/service/ServiceRollbackCommand.kt
@@ -1,0 +1,51 @@
+package io.github.joshrotenberg.dockerkotlin.core.command.service
+
+import io.github.joshrotenberg.dockerkotlin.core.CommandExecutor
+import io.github.joshrotenberg.dockerkotlin.core.command.AbstractDockerCommand
+
+/**
+ * Command to revert changes to a service's configuration.
+ *
+ * Equivalent to `docker service rollback`.
+ *
+ * Example usage:
+ * ```kotlin
+ * ServiceRollbackCommand("my-service").executeBlocking()
+ * ServiceRollbackCommand("my-service").quiet().executeBlocking()
+ * ```
+ */
+class ServiceRollbackCommand(
+    private val service: String,
+    executor: CommandExecutor = CommandExecutor()
+) : AbstractDockerCommand<String>(executor) {
+
+    private var detach = true
+    private var quiet = false
+
+    /** Run in foreground (don't detach). */
+    fun noDetach() = apply { detach = false }
+
+    /** Suppress progress output. */
+    fun quiet() = apply { quiet = true }
+
+    override fun buildArgs(): List<String> = buildList {
+        add("service")
+        add("rollback")
+        if (detach) add("--detach")
+        if (quiet) add("--quiet")
+        add(service)
+    }
+
+    override suspend fun execute(): String {
+        return executeRaw().stdout
+    }
+
+    override fun executeBlocking(): String {
+        return executeRawBlocking().stdout
+    }
+
+    companion object {
+        @JvmStatic
+        fun builder(service: String): ServiceRollbackCommand = ServiceRollbackCommand(service)
+    }
+}

--- a/docker-kotlin-core/src/main/kotlin/io/github/joshrotenberg/dockerkotlin/core/command/service/ServiceScaleCommand.kt
+++ b/docker-kotlin-core/src/main/kotlin/io/github/joshrotenberg/dockerkotlin/core/command/service/ServiceScaleCommand.kt
@@ -1,0 +1,57 @@
+package io.github.joshrotenberg.dockerkotlin.core.command.service
+
+import io.github.joshrotenberg.dockerkotlin.core.CommandExecutor
+import io.github.joshrotenberg.dockerkotlin.core.command.AbstractDockerCommand
+
+/**
+ * Command to scale one or multiple replicated services.
+ *
+ * Equivalent to `docker service scale`.
+ *
+ * Example usage:
+ * ```kotlin
+ * ServiceScaleCommand("my-service", 5).executeBlocking()
+ * ServiceScaleCommand(mapOf("service1" to 3, "service2" to 5)).executeBlocking()
+ * ```
+ */
+class ServiceScaleCommand : AbstractDockerCommand<String> {
+
+    private val scales: Map<String, Int>
+    private var detach = true
+
+    constructor(service: String, replicas: Int, executor: CommandExecutor = CommandExecutor()) : super(executor) {
+        this.scales = mapOf(service to replicas)
+    }
+
+    constructor(scales: Map<String, Int>, executor: CommandExecutor = CommandExecutor()) : super(executor) {
+        this.scales = scales
+    }
+
+    /** Run in foreground (don't detach). */
+    fun noDetach() = apply { detach = false }
+
+    override fun buildArgs(): List<String> = buildList {
+        add("service")
+        add("scale")
+        if (detach) add("--detach")
+        scales.forEach { (service, replicas) -> add("$service=$replicas") }
+    }
+
+    override suspend fun execute(): String {
+        return executeRaw().stdout
+    }
+
+    override fun executeBlocking(): String {
+        return executeRawBlocking().stdout
+    }
+
+    companion object {
+        @JvmStatic
+        fun builder(service: String, replicas: Int): ServiceScaleCommand =
+            ServiceScaleCommand(service, replicas)
+
+        @JvmStatic
+        fun builder(scales: Map<String, Int>): ServiceScaleCommand =
+            ServiceScaleCommand(scales)
+    }
+}

--- a/docker-kotlin-core/src/main/kotlin/io/github/joshrotenberg/dockerkotlin/core/command/service/ServiceUpdateCommand.kt
+++ b/docker-kotlin-core/src/main/kotlin/io/github/joshrotenberg/dockerkotlin/core/command/service/ServiceUpdateCommand.kt
@@ -1,0 +1,251 @@
+package io.github.joshrotenberg.dockerkotlin.core.command.service
+
+import io.github.joshrotenberg.dockerkotlin.core.CommandExecutor
+import io.github.joshrotenberg.dockerkotlin.core.command.AbstractDockerCommand
+
+/**
+ * Command to update a service.
+ *
+ * Equivalent to `docker service update`.
+ *
+ * Example usage:
+ * ```kotlin
+ * ServiceUpdateCommand("my-service")
+ *     .image("nginx:latest")
+ *     .replicas(5)
+ *     .executeBlocking()
+ * ```
+ */
+class ServiceUpdateCommand(
+    private val service: String,
+    executor: CommandExecutor = CommandExecutor()
+) : AbstractDockerCommand<String>(executor) {
+
+    private var image: String? = null
+    private var replicas: Int? = null
+    private var force = false
+    private var rollback = false
+    private val envAdd = mutableMapOf<String, String>()
+    private val envRm = mutableListOf<String>()
+    private val labelAdd = mutableMapOf<String, String>()
+    private val labelRm = mutableListOf<String>()
+    private val constraintAdd = mutableListOf<String>()
+    private val constraintRm = mutableListOf<String>()
+    private val portAdd = mutableListOf<String>()
+    private val portRm = mutableListOf<String>()
+    private val mountAdd = mutableListOf<String>()
+    private val mountRm = mutableListOf<String>()
+    private val networkAdd = mutableListOf<String>()
+    private val networkRm = mutableListOf<String>()
+    private val secretAdd = mutableListOf<String>()
+    private val secretRm = mutableListOf<String>()
+    private val configAdd = mutableListOf<String>()
+    private val configRm = mutableListOf<String>()
+    private var limitCpu: String? = null
+    private var limitMemory: String? = null
+    private var reserveCpu: String? = null
+    private var reserveMemory: String? = null
+    private var updateDelay: String? = null
+    private var updateParallelism: Int? = null
+    private var updateFailureAction: String? = null
+    private var updateOrder: String? = null
+    private var rollbackDelay: String? = null
+    private var rollbackParallelism: Int? = null
+    private var rollbackFailureAction: String? = null
+    private var rollbackOrder: String? = null
+    private var healthCmd: String? = null
+    private var healthInterval: String? = null
+    private var healthRetries: Int? = null
+    private var healthTimeout: String? = null
+    private var healthStartPeriod: String? = null
+    private var noHealthcheck = false
+    private var detach = true
+    private var quiet = false
+
+    /** Update the service image. */
+    fun image(image: String) = apply { this.image = image }
+
+    /** Number of tasks (replicas). */
+    fun replicas(replicas: Int) = apply { this.replicas = replicas }
+
+    /** Force update even if no changes require it. */
+    fun force() = apply { force = true }
+
+    /** Rollback to previous specification. */
+    fun rollback() = apply { rollback = true }
+
+    /** Add an environment variable. */
+    fun envAdd(key: String, value: String) = apply { envAdd[key] = value }
+
+    /** Remove an environment variable. */
+    fun envRm(key: String) = apply { envRm.add(key) }
+
+    /** Add a label. */
+    fun labelAdd(key: String, value: String) = apply { labelAdd[key] = value }
+
+    /** Remove a label. */
+    fun labelRm(key: String) = apply { labelRm.add(key) }
+
+    /** Add a placement constraint. */
+    fun constraintAdd(constraint: String) = apply { constraintAdd.add(constraint) }
+
+    /** Remove a placement constraint. */
+    fun constraintRm(constraint: String) = apply { constraintRm.add(constraint) }
+
+    /** Add a port. */
+    fun portAdd(spec: String) = apply { portAdd.add(spec) }
+
+    /** Remove a port. */
+    fun portRm(spec: String) = apply { portRm.add(spec) }
+
+    /** Add a mount. */
+    fun mountAdd(spec: String) = apply { mountAdd.add(spec) }
+
+    /** Remove a mount. */
+    fun mountRm(target: String) = apply { mountRm.add(target) }
+
+    /** Add a network. */
+    fun networkAdd(network: String) = apply { networkAdd.add(network) }
+
+    /** Remove a network. */
+    fun networkRm(network: String) = apply { networkRm.add(network) }
+
+    /** Add a secret. */
+    fun secretAdd(secret: String) = apply { secretAdd.add(secret) }
+
+    /** Remove a secret. */
+    fun secretRm(secret: String) = apply { secretRm.add(secret) }
+
+    /** Add a config. */
+    fun configAdd(config: String) = apply { configAdd.add(config) }
+
+    /** Remove a config. */
+    fun configRm(config: String) = apply { configRm.add(config) }
+
+    /** Limit CPUs. */
+    fun limitCpu(cpu: String) = apply { limitCpu = cpu }
+
+    /** Limit memory. */
+    fun limitMemory(memory: String) = apply { limitMemory = memory }
+
+    /** Reserve CPUs. */
+    fun reserveCpu(cpu: String) = apply { reserveCpu = cpu }
+
+    /** Reserve memory. */
+    fun reserveMemory(memory: String) = apply { reserveMemory = memory }
+
+    /** Delay between updates. */
+    fun updateDelay(delay: String) = apply { updateDelay = delay }
+
+    /** Maximum number of tasks updated simultaneously. */
+    fun updateParallelism(parallelism: Int) = apply { updateParallelism = parallelism }
+
+    /** Action on update failure. */
+    fun updateFailureAction(action: String) = apply { updateFailureAction = action }
+
+    /** Update order. */
+    fun updateOrder(order: String) = apply { updateOrder = order }
+
+    /** Delay between rollback attempts. */
+    fun rollbackDelay(delay: String) = apply { rollbackDelay = delay }
+
+    /** Maximum number of tasks rolled back simultaneously. */
+    fun rollbackParallelism(parallelism: Int) = apply { rollbackParallelism = parallelism }
+
+    /** Action on rollback failure. */
+    fun rollbackFailureAction(action: String) = apply { rollbackFailureAction = action }
+
+    /** Rollback order. */
+    fun rollbackOrder(order: String) = apply { rollbackOrder = order }
+
+    /** Health check command. */
+    fun healthCmd(cmd: String) = apply { healthCmd = cmd }
+
+    /** Health check interval. */
+    fun healthInterval(interval: String) = apply { healthInterval = interval }
+
+    /** Health check retries. */
+    fun healthRetries(retries: Int) = apply { healthRetries = retries }
+
+    /** Health check timeout. */
+    fun healthTimeout(timeout: String) = apply { healthTimeout = timeout }
+
+    /** Health check start period. */
+    fun healthStartPeriod(period: String) = apply { healthStartPeriod = period }
+
+    /** Disable health check. */
+    fun noHealthcheck() = apply { noHealthcheck = true }
+
+    /** Run in foreground (don't detach). */
+    fun noDetach() = apply { detach = false }
+
+    /** Suppress progress output. */
+    fun quiet() = apply { quiet = true }
+
+    override fun buildArgs(): List<String> = buildList {
+        add("service")
+        add("update")
+
+        image?.let { add("--image"); add(it) }
+        replicas?.let { add("--replicas"); add(it.toString()) }
+        if (force) add("--force")
+        if (rollback) add("--rollback")
+
+        envAdd.forEach { (key, value) -> add("--env-add"); add("$key=$value") }
+        envRm.forEach { add("--env-rm"); add(it) }
+        labelAdd.forEach { (key, value) -> add("--label-add"); add("$key=$value") }
+        labelRm.forEach { add("--label-rm"); add(it) }
+        constraintAdd.forEach { add("--constraint-add"); add(it) }
+        constraintRm.forEach { add("--constraint-rm"); add(it) }
+        portAdd.forEach { add("--publish-add"); add(it) }
+        portRm.forEach { add("--publish-rm"); add(it) }
+        mountAdd.forEach { add("--mount-add"); add(it) }
+        mountRm.forEach { add("--mount-rm"); add(it) }
+        networkAdd.forEach { add("--network-add"); add(it) }
+        networkRm.forEach { add("--network-rm"); add(it) }
+        secretAdd.forEach { add("--secret-add"); add(it) }
+        secretRm.forEach { add("--secret-rm"); add(it) }
+        configAdd.forEach { add("--config-add"); add(it) }
+        configRm.forEach { add("--config-rm"); add(it) }
+
+        limitCpu?.let { add("--limit-cpu"); add(it) }
+        limitMemory?.let { add("--limit-memory"); add(it) }
+        reserveCpu?.let { add("--reserve-cpu"); add(it) }
+        reserveMemory?.let { add("--reserve-memory"); add(it) }
+
+        updateDelay?.let { add("--update-delay"); add(it) }
+        updateParallelism?.let { add("--update-parallelism"); add(it.toString()) }
+        updateFailureAction?.let { add("--update-failure-action"); add(it) }
+        updateOrder?.let { add("--update-order"); add(it) }
+
+        rollbackDelay?.let { add("--rollback-delay"); add(it) }
+        rollbackParallelism?.let { add("--rollback-parallelism"); add(it.toString()) }
+        rollbackFailureAction?.let { add("--rollback-failure-action"); add(it) }
+        rollbackOrder?.let { add("--rollback-order"); add(it) }
+
+        healthCmd?.let { add("--health-cmd"); add(it) }
+        healthInterval?.let { add("--health-interval"); add(it) }
+        healthRetries?.let { add("--health-retries"); add(it.toString()) }
+        healthTimeout?.let { add("--health-timeout"); add(it) }
+        healthStartPeriod?.let { add("--health-start-period"); add(it) }
+
+        if (noHealthcheck) add("--no-healthcheck")
+        if (detach) add("--detach")
+        if (quiet) add("--quiet")
+
+        add(service)
+    }
+
+    override suspend fun execute(): String {
+        return executeRaw().stdout
+    }
+
+    override fun executeBlocking(): String {
+        return executeRawBlocking().stdout
+    }
+
+    companion object {
+        @JvmStatic
+        fun builder(service: String): ServiceUpdateCommand = ServiceUpdateCommand(service)
+    }
+}

--- a/docker-kotlin-core/src/main/kotlin/io/github/joshrotenberg/dockerkotlin/core/command/stack/StackConfigCommand.kt
+++ b/docker-kotlin-core/src/main/kotlin/io/github/joshrotenberg/dockerkotlin/core/command/stack/StackConfigCommand.kt
@@ -1,0 +1,55 @@
+package io.github.joshrotenberg.dockerkotlin.core.command.stack
+
+import io.github.joshrotenberg.dockerkotlin.core.CommandExecutor
+import io.github.joshrotenberg.dockerkotlin.core.command.AbstractDockerCommand
+
+/**
+ * Command to output the final config file, after doing merges and interpolations.
+ *
+ * Equivalent to `docker stack config`.
+ *
+ * Example usage:
+ * ```kotlin
+ * StackConfigCommand("docker-compose.yml").executeBlocking()
+ * StackConfigCommand(listOf("docker-compose.yml", "docker-compose.prod.yml")).executeBlocking()
+ * ```
+ */
+class StackConfigCommand : AbstractDockerCommand<String> {
+
+    private val composeFiles: List<String>
+    private var skipInterpolation = false
+
+    constructor(composeFile: String, executor: CommandExecutor = CommandExecutor()) : super(executor) {
+        this.composeFiles = listOf(composeFile)
+    }
+
+    constructor(composeFiles: List<String>, executor: CommandExecutor = CommandExecutor()) : super(executor) {
+        this.composeFiles = composeFiles
+    }
+
+    /** Skip interpolation and output only merged config. */
+    fun skipInterpolation() = apply { skipInterpolation = true }
+
+    override fun buildArgs(): List<String> = buildList {
+        add("stack")
+        add("config")
+        composeFiles.forEach { add("--compose-file"); add(it) }
+        if (skipInterpolation) add("--skip-interpolation")
+    }
+
+    override suspend fun execute(): String {
+        return executeRaw().stdout
+    }
+
+    override fun executeBlocking(): String {
+        return executeRawBlocking().stdout
+    }
+
+    companion object {
+        @JvmStatic
+        fun builder(composeFile: String): StackConfigCommand = StackConfigCommand(composeFile)
+
+        @JvmStatic
+        fun builder(composeFiles: List<String>): StackConfigCommand = StackConfigCommand(composeFiles)
+    }
+}

--- a/docker-kotlin-core/src/main/kotlin/io/github/joshrotenberg/dockerkotlin/core/command/stack/StackDeployCommand.kt
+++ b/docker-kotlin-core/src/main/kotlin/io/github/joshrotenberg/dockerkotlin/core/command/stack/StackDeployCommand.kt
@@ -1,0 +1,91 @@
+package io.github.joshrotenberg.dockerkotlin.core.command.stack
+
+import io.github.joshrotenberg.dockerkotlin.core.CommandExecutor
+import io.github.joshrotenberg.dockerkotlin.core.command.AbstractDockerCommand
+
+/**
+ * Command to deploy a new stack or update an existing stack.
+ *
+ * Equivalent to `docker stack deploy`.
+ *
+ * Example usage:
+ * ```kotlin
+ * StackDeployCommand("my-stack", "docker-compose.yml").executeBlocking()
+ * StackDeployCommand("my-stack", listOf("docker-compose.yml", "docker-compose.prod.yml"))
+ *     .withRegistryAuth()
+ *     .executeBlocking()
+ * ```
+ */
+class StackDeployCommand : AbstractDockerCommand<String> {
+
+    private val stack: String
+    private val composeFiles: List<String>
+    private var prune = false
+    private var resolveImage: String? = null
+    private var withRegistryAuth = false
+    private var detach = true
+    private var quiet = false
+
+    constructor(
+        stack: String,
+        composeFile: String,
+        executor: CommandExecutor = CommandExecutor()
+    ) : super(executor) {
+        this.stack = stack
+        this.composeFiles = listOf(composeFile)
+    }
+
+    constructor(
+        stack: String,
+        composeFiles: List<String>,
+        executor: CommandExecutor = CommandExecutor()
+    ) : super(executor) {
+        this.stack = stack
+        this.composeFiles = composeFiles
+    }
+
+    /** Prune services that are no longer referenced. */
+    fun prune() = apply { prune = true }
+
+    /** Query the registry to resolve image digest and supported platforms (always, changed, never). */
+    fun resolveImage(mode: String) = apply { resolveImage = mode }
+
+    /** Send registry authentication details to Swarm agents. */
+    fun withRegistryAuth() = apply { withRegistryAuth = true }
+
+    /** Run in foreground (don't detach). */
+    fun noDetach() = apply { detach = false }
+
+    /** Suppress progress output. */
+    fun quiet() = apply { quiet = true }
+
+    override fun buildArgs(): List<String> = buildList {
+        add("stack")
+        add("deploy")
+        composeFiles.forEach { add("--compose-file"); add(it) }
+        if (prune) add("--prune")
+        resolveImage?.let { add("--resolve-image"); add(it) }
+        if (withRegistryAuth) add("--with-registry-auth")
+        if (detach) add("--detach")
+        if (quiet) add("--quiet")
+        add(stack)
+    }
+
+    override suspend fun execute(): String {
+        return executeRaw().stdout
+    }
+
+    override fun executeBlocking(): String {
+        return executeRawBlocking().stdout
+    }
+
+    companion object {
+        @JvmStatic
+        fun builder(stack: String, composeFile: String): StackDeployCommand =
+            StackDeployCommand(stack, composeFile)
+
+        @JvmStatic
+        fun builder(stack: String, composeFiles: List<String>): StackDeployCommand =
+            StackDeployCommand(stack, composeFiles)
+    }
+}

--- a/docker-kotlin-core/src/main/kotlin/io/github/joshrotenberg/dockerkotlin/core/command/stack/StackLsCommand.kt
+++ b/docker-kotlin-core/src/main/kotlin/io/github/joshrotenberg/dockerkotlin/core/command/stack/StackLsCommand.kt
@@ -1,0 +1,44 @@
+package io.github.joshrotenberg.dockerkotlin.core.command.stack
+
+import io.github.joshrotenberg.dockerkotlin.core.CommandExecutor
+import io.github.joshrotenberg.dockerkotlin.core.command.AbstractDockerCommand
+
+/**
+ * Command to list stacks.
+ *
+ * Equivalent to `docker stack ls`.
+ *
+ * Example usage:
+ * ```kotlin
+ * StackLsCommand().executeBlocking()
+ * StackLsCommand().format("{{.Name}}").executeBlocking()
+ * ```
+ */
+class StackLsCommand(
+    executor: CommandExecutor = CommandExecutor()
+) : AbstractDockerCommand<String>(executor) {
+
+    private var format: String? = null
+
+    /** Format output using a Go template. */
+    fun format(format: String) = apply { this.format = format }
+
+    override fun buildArgs(): List<String> = buildList {
+        add("stack")
+        add("ls")
+        format?.let { add("--format"); add(it) }
+    }
+
+    override suspend fun execute(): String {
+        return executeRaw().stdout
+    }
+
+    override fun executeBlocking(): String {
+        return executeRawBlocking().stdout
+    }
+
+    companion object {
+        @JvmStatic
+        fun builder(): StackLsCommand = StackLsCommand()
+    }
+}

--- a/docker-kotlin-core/src/main/kotlin/io/github/joshrotenberg/dockerkotlin/core/command/stack/StackPsCommand.kt
+++ b/docker-kotlin-core/src/main/kotlin/io/github/joshrotenberg/dockerkotlin/core/command/stack/StackPsCommand.kt
@@ -1,0 +1,67 @@
+package io.github.joshrotenberg.dockerkotlin.core.command.stack
+
+import io.github.joshrotenberg.dockerkotlin.core.CommandExecutor
+import io.github.joshrotenberg.dockerkotlin.core.command.AbstractDockerCommand
+
+/**
+ * Command to list the tasks in the stack.
+ *
+ * Equivalent to `docker stack ps`.
+ *
+ * Example usage:
+ * ```kotlin
+ * StackPsCommand("my-stack").executeBlocking()
+ * StackPsCommand("my-stack").filter("desired-state", "running").executeBlocking()
+ * StackPsCommand("my-stack").noTrunc().quiet().executeBlocking()
+ * ```
+ */
+class StackPsCommand(
+    private val stack: String,
+    executor: CommandExecutor = CommandExecutor()
+) : AbstractDockerCommand<String>(executor) {
+
+    private val filters = mutableMapOf<String, String>()
+    private var format: String? = null
+    private var noResolve = false
+    private var noTrunc = false
+    private var quiet = false
+
+    /** Filter output based on conditions provided. */
+    fun filter(key: String, value: String) = apply { filters[key] = value }
+
+    /** Format output using a Go template. */
+    fun format(format: String) = apply { this.format = format }
+
+    /** Do not map IDs to names. */
+    fun noResolve() = apply { noResolve = true }
+
+    /** Do not truncate output. */
+    fun noTrunc() = apply { noTrunc = true }
+
+    /** Only display task IDs. */
+    fun quiet() = apply { quiet = true }
+
+    override fun buildArgs(): List<String> = buildList {
+        add("stack")
+        add("ps")
+        filters.forEach { (key, value) -> add("--filter"); add("$key=$value") }
+        format?.let { add("--format"); add(it) }
+        if (noResolve) add("--no-resolve")
+        if (noTrunc) add("--no-trunc")
+        if (quiet) add("--quiet")
+        add(stack)
+    }
+
+    override suspend fun execute(): String {
+        return executeRaw().stdout
+    }
+
+    override fun executeBlocking(): String {
+        return executeRawBlocking().stdout
+    }
+
+    companion object {
+        @JvmStatic
+        fun builder(stack: String): StackPsCommand = StackPsCommand(stack)
+    }
+}

--- a/docker-kotlin-core/src/main/kotlin/io/github/joshrotenberg/dockerkotlin/core/command/stack/StackRmCommand.kt
+++ b/docker-kotlin-core/src/main/kotlin/io/github/joshrotenberg/dockerkotlin/core/command/stack/StackRmCommand.kt
@@ -1,0 +1,55 @@
+package io.github.joshrotenberg.dockerkotlin.core.command.stack
+
+import io.github.joshrotenberg.dockerkotlin.core.CommandExecutor
+import io.github.joshrotenberg.dockerkotlin.core.command.AbstractDockerCommand
+
+/**
+ * Command to remove one or more stacks.
+ *
+ * Equivalent to `docker stack rm`.
+ *
+ * Example usage:
+ * ```kotlin
+ * StackRmCommand("my-stack").executeBlocking()
+ * StackRmCommand(listOf("stack1", "stack2")).executeBlocking()
+ * ```
+ */
+class StackRmCommand : AbstractDockerCommand<String> {
+
+    private val stacks: List<String>
+    private var detach = true
+
+    constructor(stack: String, executor: CommandExecutor = CommandExecutor()) : super(executor) {
+        this.stacks = listOf(stack)
+    }
+
+    constructor(stacks: List<String>, executor: CommandExecutor = CommandExecutor()) : super(executor) {
+        this.stacks = stacks
+    }
+
+    /** Run in foreground (don't detach). */
+    fun noDetach() = apply { detach = false }
+
+    override fun buildArgs(): List<String> = buildList {
+        add("stack")
+        add("rm")
+        if (detach) add("--detach")
+        addAll(stacks)
+    }
+
+    override suspend fun execute(): String {
+        return executeRaw().stdout
+    }
+
+    override fun executeBlocking(): String {
+        return executeRawBlocking().stdout
+    }
+
+    companion object {
+        @JvmStatic
+        fun builder(stack: String): StackRmCommand = StackRmCommand(stack)
+
+        @JvmStatic
+        fun builder(stacks: List<String>): StackRmCommand = StackRmCommand(stacks)
+    }
+}

--- a/docker-kotlin-core/src/main/kotlin/io/github/joshrotenberg/dockerkotlin/core/command/stack/StackServicesCommand.kt
+++ b/docker-kotlin-core/src/main/kotlin/io/github/joshrotenberg/dockerkotlin/core/command/stack/StackServicesCommand.kt
@@ -1,0 +1,57 @@
+package io.github.joshrotenberg.dockerkotlin.core.command.stack
+
+import io.github.joshrotenberg.dockerkotlin.core.CommandExecutor
+import io.github.joshrotenberg.dockerkotlin.core.command.AbstractDockerCommand
+
+/**
+ * Command to list the services in the stack.
+ *
+ * Equivalent to `docker stack services`.
+ *
+ * Example usage:
+ * ```kotlin
+ * StackServicesCommand("my-stack").executeBlocking()
+ * StackServicesCommand("my-stack").filter("name", "web").executeBlocking()
+ * StackServicesCommand("my-stack").quiet().executeBlocking()
+ * ```
+ */
+class StackServicesCommand(
+    private val stack: String,
+    executor: CommandExecutor = CommandExecutor()
+) : AbstractDockerCommand<String>(executor) {
+
+    private val filters = mutableMapOf<String, String>()
+    private var format: String? = null
+    private var quiet = false
+
+    /** Filter output based on conditions provided. */
+    fun filter(key: String, value: String) = apply { filters[key] = value }
+
+    /** Format output using a Go template. */
+    fun format(format: String) = apply { this.format = format }
+
+    /** Only display service IDs. */
+    fun quiet() = apply { quiet = true }
+
+    override fun buildArgs(): List<String> = buildList {
+        add("stack")
+        add("services")
+        filters.forEach { (key, value) -> add("--filter"); add("$key=$value") }
+        format?.let { add("--format"); add(it) }
+        if (quiet) add("--quiet")
+        add(stack)
+    }
+
+    override suspend fun execute(): String {
+        return executeRaw().stdout
+    }
+
+    override fun executeBlocking(): String {
+        return executeRawBlocking().stdout
+    }
+
+    companion object {
+        @JvmStatic
+        fun builder(stack: String): StackServicesCommand = StackServicesCommand(stack)
+    }
+}


### PR DESCRIPTION
This PR adds 44 new commands to achieve 100% Docker CLI command coverage.

## Summary

Total command count: **127 commands** covering all Docker CLI functionality.

## New Command Groups

### Image (1 command)
- `ImageInspectCommand` - Display detailed information on images

### Plugin (10 commands)
- `PluginCreateCommand` - Create a plugin from a rootfs
- `PluginDisableCommand` - Disable a plugin
- `PluginEnableCommand` - Enable a plugin
- `PluginInspectCommand` - Display detailed information on plugins
- `PluginInstallCommand` - Install a plugin
- `PluginLsCommand` - List plugins
- `PluginPushCommand` - Push a plugin to a registry
- `PluginRmCommand` - Remove plugins
- `PluginSetCommand` - Change plugin settings
- `PluginUpgradeCommand` - Upgrade a plugin

### Config (4 commands) - Swarm configs
- `ConfigCreateCommand` - Create a config
- `ConfigInspectCommand` - Display detailed information on configs
- `ConfigLsCommand` - List configs
- `ConfigRmCommand` - Remove configs

### Secret (4 commands) - Swarm secrets
- `SecretCreateCommand` - Create a secret
- `SecretInspectCommand` - Display detailed information on secrets
- `SecretLsCommand` - List secrets
- `SecretRmCommand` - Remove secrets

### Service (9 commands) - Swarm services
- `ServiceCreateCommand` - Create a new service
- `ServiceInspectCommand` - Display detailed information on services
- `ServiceLogsCommand` - Fetch service logs
- `ServiceLsCommand` - List services
- `ServicePsCommand` - List tasks of a service
- `ServiceRmCommand` - Remove services
- `ServiceRollbackCommand` - Revert service changes
- `ServiceScaleCommand` - Scale replicated services
- `ServiceUpdateCommand` - Update a service

### Stack (6 commands) - Swarm stacks
- `StackConfigCommand` - Output merged compose config
- `StackDeployCommand` - Deploy a stack
- `StackLsCommand` - List stacks
- `StackPsCommand` - List tasks in a stack
- `StackRmCommand` - Remove stacks
- `StackServicesCommand` - List services in a stack

### Node (7 commands) - Swarm nodes
- `NodeDemoteCommand` - Demote manager nodes
- `NodeInspectCommand` - Display detailed information on nodes
- `NodeLsCommand` - List nodes
- `NodePromoteCommand` - Promote nodes to manager
- `NodePsCommand` - List tasks running on nodes
- `NodeRmCommand` - Remove nodes
- `NodeUpdateCommand` - Update node settings

## Command Coverage Summary

| Category | Commands |
|----------|----------|
| Container | 24 |
| Image | 12 |
| Network | 7 |
| Volume | 5 |
| System | 5 |
| Builder | 7 |
| Context | 9 |
| Manifest | 5 |
| Swarm | 8 |
| Plugin | 10 |
| Config | 4 |
| Secret | 4 |
| Service | 9 |
| Stack | 6 |
| Node | 7 |
| Auth | 3 |
| **Total** | **127** |